### PR TITLE
Korjaa: hibernate hakee sisäisessä vertailussaan kaikki henkilöt joilla on sama kielisyys

### DIFF
--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Kansalaisuus.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Kansalaisuus.java
@@ -12,7 +12,7 @@ import java.util.Set;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = false, exclude = "henkilos")
 @Entity
 public class Kansalaisuus extends IdentifiableAndVersionedEntity {
     private static final long serialVersionUID = 1807970088588578536L;

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Kielisyys.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Kielisyys.java
@@ -6,7 +6,7 @@ import javax.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
 
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = false, exclude = "henkilos")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
-Exclude henkilos from Kielisyys and Kansalaisuus hashcode.