### PR TITLE
Allows ignoring of unknown properties in yml configurations.

### DIFF
--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/properties/AuthenticationProperties.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/properties/AuthenticationProperties.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "authentication", ignoreUnknownFields = false, ignoreInvalidFields = false)
+@ConfigurationProperties(prefix = "authentication")
 public class AuthenticationProperties {
     @Getter
     @Setter

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/properties/CasProperties.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/properties/CasProperties.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "cas", ignoreUnknownFields = false, ignoreInvalidFields = false)
+@ConfigurationProperties(prefix = "cas")
 public class CasProperties {
     @Getter
     @Setter

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/properties/DevProperties.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/properties/DevProperties.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 @Configuration
-@ConfigurationProperties(prefix = "dev", ignoreUnknownFields = false, ignoreInvalidFields = false)
+@ConfigurationProperties(prefix = "dev")
 public class DevProperties {
     private String username;
     private String password;

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/properties/HikariProperties.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/properties/HikariProperties.java
@@ -5,6 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConfigurationProperties(prefix = "hikari.datasource", ignoreUnknownFields = false)
+@ConfigurationProperties(prefix = "hikari.datasource")
 public class HikariProperties extends HikariConfig {
 }


### PR DESCRIPTION
Previously preparing to new features in e.g. api tests caused problems when run against different branches. Would cause the same problem locally in development: a developer wouldn't be able to have configuration supporting different branches.

Also delete ignoreInvalidFields (default is false).