### PR TITLE
Order changed oids by modified

### DIFF
--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloJpaRepository.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloJpaRepository.java
@@ -36,7 +36,7 @@ public interface HenkiloJpaRepository {
      */
     Optional<Henkilo> findMasterBySlaveOid(String henkiloOid);
 
-    List<String> findOidsModifiedSince(HenkiloCriteria criteria, DateTime modifiedSince);
+    List<String> findOidsModifiedSince(HenkiloCriteria criteria, DateTime modifiedSince, Integer offset, Integer amount);
 
     Optional<Henkilo> findByExternalId(String externalId);
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
@@ -164,7 +164,7 @@ public class HenkiloRepositoryImpl extends AbstractRepository implements Henkilo
         return jpa().from(henkilo).where(criteria.condition(henkilo)
                     .and(henkilo.modified.goe(modifiedSince.toDate())))
                 .select(henkilo.oidHenkilo)
-                .orderBy(henkilo.oidHenkilo.asc()).fetch();
+                .orderBy(henkilo.modified.asc()).fetch();
     }
 
     @Override

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
@@ -160,11 +160,18 @@ public class HenkiloRepositoryImpl extends AbstractRepository implements Henkilo
     }
 
     @Override
-    public List<String> findOidsModifiedSince(HenkiloCriteria criteria, DateTime modifiedSince) {
-        return jpa().from(henkilo).where(criteria.condition(henkilo)
+    public List<String> findOidsModifiedSince(HenkiloCriteria criteria, DateTime modifiedSince, Integer offset, Integer amount) {
+        JPAQuery<String> query = jpa().from(henkilo).where(criteria.condition(henkilo)
                     .and(henkilo.modified.goe(modifiedSince.toDate())))
                 .select(henkilo.oidHenkilo)
-                .orderBy(henkilo.modified.asc()).fetch();
+                .orderBy(henkilo.modified.desc());
+        if(offset != null) {
+            query.offset(offset);
+        }
+        if(amount != null) {
+            query.limit(amount);
+        }
+        return query.fetch();
     }
 
     @Override

--- a/oppijanumerorekisteri-domain/src/test/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloRepositoryTests.java
+++ b/oppijanumerorekisteri-domain/src/test/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloRepositoryTests.java
@@ -30,7 +30,6 @@ import java.time.Month;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-// NOTE: Model validators have separate test.
 @RunWith(SpringRunner.class)
 @DataJpaTest
 @Transactional(readOnly = true)
@@ -296,19 +295,56 @@ public class HenkiloRepositoryTests extends AbstractRepositoryTest {
         populate(henkilo("LAST_WEEK").modified(lastWeek));
         populate(henkilo("MOMENT_AGO").modified(now.minusMinutes(1)));
 
-        List<String> results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now);
+        List<String> results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now, null, null);
         assertThat(results).hasSize(0);
 
-        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now.minusHours(1));
+        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now.minusHours(1), null, null);
         assertThat(results).hasSize(1);
         assertThat(results.get(0)).isEqualTo("MOMENT_AGO");
         
         results = this.jpaRepository.findOidsModifiedSince(HenkiloCriteria.builder()
-                .henkiloOids(new HashSet<>(asList("YESTERDAY", "LAST_WEEK"))).build(), yesterday);
+                .henkiloOids(new HashSet<>(asList("YESTERDAY", "LAST_WEEK"))).build(), yesterday, null, null);
         assertThat(results).hasSize(1);
         assertThat(results.get(0)).isEqualTo("YESTERDAY");
         
-        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), lastWeek);
+        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), lastWeek, null, null);
         assertThat(results).hasSize(3);
+    }
+
+    @Test
+    public void findOidsModifiedSinceWithOffsetAndAmount() {
+        DateTime now = new DateTime(),
+                yesterday = now.minusDays(1),
+                lastWeek = now.minusWeeks(1);
+        populate(henkilo("YESTERDAY").modified(yesterday));
+        populate(henkilo("LAST_WEEK").modified(lastWeek));
+        populate(henkilo("MOMENT_AGO1").modified(now.minusMinutes(1)));
+        populate(henkilo("MOMENT_AGO2").modified(now.minusMinutes(2)));
+        populate(henkilo("MOMENT_AGO3").modified(now.minusMinutes(3)));
+        populate(henkilo("MOMENT_AGO4").modified(now.minusMinutes(4)));
+
+        List<String> results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now.minusHours(1), null, null);
+        assertThat(results).hasSize(4);
+        assertThat(results).containsAll(Sets.newHashSet("MOMENT_AGO1", "MOMENT_AGO2", "MOMENT_AGO3", "MOMENT_AGO4"));
+
+        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now.minusHours(1), 2, null);
+        assertThat(results).hasSize(2);
+        assertThat(results).containsAll(Sets.newHashSet("MOMENT_AGO3", "MOMENT_AGO4"));
+
+        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now.minusHours(1), null, 2);
+        assertThat(results).hasSize(2);
+        assertThat(results).containsAll(Sets.newHashSet("MOMENT_AGO1", "MOMENT_AGO2"));
+
+        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now.minusHours(1), 1, 1);
+        assertThat(results).hasSize(1);
+        assertThat(results).containsAll(Sets.newHashSet("MOMENT_AGO2"));
+
+        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now.minusHours(1), 100, 100);
+        assertThat(results).hasSize(0);
+
+        results = this.jpaRepository.findOidsModifiedSince(new HenkiloCriteria(), now.minusHours(1), 1, 100);
+        assertThat(results).hasSize(3);
+        assertThat(results).containsAll(Sets.newHashSet("MOMENT_AGO2", "MOMENT_AGO3", "MOMENT_AGO4"));
+
     }
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceController.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceController.java
@@ -61,18 +61,23 @@ public class Service2ServiceController {
         return this.henkiloService.findHenkiloViittees(criteria);
     }
 
-    @ApiOperation(value = "Hakee muuttuneet henkilöt annetusta päivämäärästä")
+    @ApiOperation(value = "Hakee muuttuneet henkilöt annetusta päivämäärästä aikajärjestyksessä",
+            notes = "Sivutusta käytettäessä OID:t palautetaan vanhemmasta uudempaan mutta sivun sisäinen järjestys voi muuttua matkalla!")
     @PreAuthorize("hasRole('APP_HENKILONHALLINTA_OPHREKISTERI')")
     @RequestMapping(value = "/changedSince/{at}", method = RequestMethod.GET)
-    public List<String> findChangedPersons(@PathVariable DateTime at) {
-        return this.henkiloService.findHenkiloOidsModifiedSince(new HenkiloCriteria(), at);
+    public List<String> findChangedPersons(@PathVariable DateTime at, @RequestParam(required = false) Integer offset,
+                                           @RequestParam(required = false) Integer amount) {
+        return this.henkiloService.findHenkiloOidsModifiedSince(new HenkiloCriteria(), at, offset, amount);
     }
 
-    @ApiOperation(value = "Hakee muuttuneet henkilöt annetusta päivämäärästä hakuehdoilla")
+    @ApiOperation(value = "Hakee muuttuneet henkilöt annetusta päivämäärästä hakuehdoilla aikajärjestyksessä",
+            notes = "Sivutusta käytettäessä OID:t palautetaan vanhemmasta uudempaan mutta sivun sisäinen järjestys voi muuttua matkalla!")
     @PreAuthorize("hasRole('APP_HENKILONHALLINTA_OPHREKISTERI')")
     @RequestMapping(value = "/changedSince/{at}", method = RequestMethod.POST)
-    public List<String> findChangedPersons(@RequestBody HenkiloCriteria criteria, @PathVariable DateTime at) {
-        return this.henkiloService.findHenkiloOidsModifiedSince(criteria, at);
+    public List<String> findChangedPersons(@RequestBody HenkiloCriteria criteria, @PathVariable DateTime at,
+                                           @RequestParam(required = false) Integer offset,
+                                           @RequestParam(required = false) Integer amount) {
+        return this.henkiloService.findHenkiloOidsModifiedSince(criteria, at, offset, amount);
     }
 
     @ApiOperation(value = "Hakee tai luo uuden henkilön annetuista henkilon perustiedoista")

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloService.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloService.java
@@ -47,7 +47,7 @@ public interface HenkiloService {
 
     List<HenkiloViiteDto> findHenkiloViittees(HenkiloCriteria criteria);
 
-    List<String> findHenkiloOidsModifiedSince(HenkiloCriteria criteria, DateTime modifiedSince);
+    List<String> findHenkiloOidsModifiedSince(HenkiloCriteria criteria, DateTime modifiedSince, Integer offset, Integer amount);
 
     Henkilo createHenkilo(Henkilo henkiloCreate);
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
@@ -310,8 +310,8 @@ public class HenkiloServiceImpl implements HenkiloService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<String> findHenkiloOidsModifiedSince(HenkiloCriteria criteria, DateTime modifiedSince) {
-        return this.henkiloJpaRepository.findOidsModifiedSince(criteria, modifiedSince);
+    public List<String> findHenkiloOidsModifiedSince(HenkiloCriteria criteria, DateTime modifiedSince, Integer offset, Integer amount) {
+        return this.henkiloJpaRepository.findOidsModifiedSince(criteria, modifiedSince, offset, amount);
     }
 
     @Override

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceControllerTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceControllerTest.java
@@ -98,42 +98,42 @@ public class Service2ServiceControllerTest  {
     @Test
     @WithMockUser
     public void findChangedPersonsGet() throws Exception {
-        given(this.henkiloService.findHenkiloOidsModifiedSince(any(), any())).willReturn(singletonList("1.2.3"));
+        given(this.henkiloService.findHenkiloOidsModifiedSince(any(), any(), any(), any())).willReturn(singletonList("1.2.3"));
         this.mvc.perform(get("/s2s/changedSince/2015-10-12T10:10:10")
                 .accept(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk()).andExpect(content()
                 .json("[\"1.2.3\"]"));
-        verify(this.henkiloService).findHenkiloOidsModifiedSince(new HenkiloCriteria(), new DateTime(2015,10,12,10,10,10));
+        verify(this.henkiloService).findHenkiloOidsModifiedSince(new HenkiloCriteria(), new DateTime(2015,10,12,10,10,10), null, null);
         
-        given(this.henkiloService.findHenkiloOidsModifiedSince(any(), any())).willReturn(emptyList());
+        given(this.henkiloService.findHenkiloOidsModifiedSince(any(), any(), any(), any())).willReturn(emptyList());
         this.mvc.perform(get("/s2s/changedSince/2015-10-12")
                 .accept(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk()).andExpect(content().json("[]"));
-        verify(this.henkiloService).findHenkiloOidsModifiedSince(new HenkiloCriteria(), new DateTime(2015,10,12,0,0,0));
+        verify(this.henkiloService).findHenkiloOidsModifiedSince(new HenkiloCriteria(), new DateTime(2015,10,12,0,0,0), null, null);
     }
     
     @Test
     @WithMockUser
     public void findChangedPersonsGetByTimestamp() throws Exception {
-        given(this.henkiloService.findHenkiloOidsModifiedSince(any(), any())).willReturn(emptyList());
+        given(this.henkiloService.findHenkiloOidsModifiedSince(any(), any(), any(), any())).willReturn(emptyList());
         DateTime dt = new DateTime(2015,10,12,0,0,0);
         this.mvc.perform(get("/s2s/changedSince/" + dt.toDate().getTime())
                 .accept(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk()).andExpect(content().json("[]"));
-        verify(this.henkiloService).findHenkiloOidsModifiedSince(new HenkiloCriteria(), dt);
+        verify(this.henkiloService).findHenkiloOidsModifiedSince(new HenkiloCriteria(), dt, null, null);
     }
 
     @Test
     @WithMockUser
     public void findChangedPersonsPost() throws Exception {
         HenkiloCriteria criteria = HenkiloCriteria.builder().henkiloOids(new HashSet<>(singletonList("1.2.3"))).build();
-        given(this.henkiloService.findHenkiloOidsModifiedSince(any(), any())).willReturn(singletonList("1.2.3"));
+        given(this.henkiloService.findHenkiloOidsModifiedSince(any(), any(), any(), any())).willReturn(singletonList("1.2.3"));
         this.mvc.perform(post("/s2s/changedSince/2015-10-12T10:10:10").content("{\"henkiloOids\": [\"1.2.3\"]}")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk()).andExpect(content()
                 .json("[\"1.2.3\"]"));
-        verify(this.henkiloService).findHenkiloOidsModifiedSince(criteria, new DateTime(2015,10,12,10,10,10));
+        verify(this.henkiloService).findHenkiloOidsModifiedSince(criteria, new DateTime(2015,10,12,10,10,10), null, null);
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImplTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImplTest.java
@@ -117,18 +117,18 @@ public class HenkiloServiceImplTest {
 
     @Test
     public void findHenkiloOidsModifiedSinceTest() {
-        when(henkiloJpaRepository.findOidsModifiedSince(any(), any())).thenReturn(singletonList("1.2.3"));
+        when(henkiloJpaRepository.findOidsModifiedSince(any(), any(), any(), any())).thenReturn(singletonList("1.2.3"));
 
         HenkiloCriteria criteria = HenkiloCriteria.builder()
                 .henkiloOids(new HashSet<>(asList("1.2.3", "4.5.6"))).build();
         DateTime dt = new DateTime();
-        List<String> result = impl.findHenkiloOidsModifiedSince(criteria, dt);
+        List<String> result = impl.findHenkiloOidsModifiedSince(criteria, dt, null, null);
 
         assertThat(result).isEqualTo(singletonList("1.2.3"));
-        verify(henkiloJpaRepository).findOidsModifiedSince(eq(criteria), eq(dt));
+        verify(henkiloJpaRepository).findOidsModifiedSince(eq(criteria), eq(dt), eq(null), eq(null));
 
-        when(henkiloJpaRepository.findOidsModifiedSince(any(), any())).thenReturn(emptyList());
-        result = impl.findHenkiloOidsModifiedSince(criteria, dt);
+        when(henkiloJpaRepository.findOidsModifiedSince(any(), any(), any(), any())).thenReturn(emptyList());
+        result = impl.findHenkiloOidsModifiedSince(criteria, dt, null, null);
         assertThat(result).hasSize(0);
     }
 


### PR DESCRIPTION
Olisi perustellumpaa palauttaa muuttuneet muuttumisaikajärjestyksessä. Näin voimme hakeassamme muuttuneiden tietoja rakentaa sen varaan, että viimeisimmät listassa on viimeiseksi muuttuneita.