### PR TITLE
Kjhh 1257 turvakiellon päivitys + henkiloservice siistiminen

### DIFF
--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceUpdateDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceUpdateDto.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
+// NOTE: Since this works like patch is initialising null to all fields reasonable to prevent accidental list overrides
 public class HenkiloForceUpdateDto extends HenkiloUpdateDto {
     private Boolean turvakielto;
 

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceUpdateDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceUpdateDto.java
@@ -1,0 +1,11 @@
+package fi.vm.sade.oppijanumerorekisteri.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class HenkiloForceUpdateDto extends HenkiloUpdateDto {
+    private Boolean turvakielto;
+
+}

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloUpdateDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloUpdateDto.java
@@ -15,6 +15,7 @@ import java.util.Set;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+// NOTE: Since this works like patch is initialising null to all fields reasonable to prevent accidental list overrides
 public class HenkiloUpdateDto {
     private String oidHenkilo;
 
@@ -38,11 +39,11 @@ public class HenkiloUpdateDto {
 
     private KielisyysDto aidinkieli;
 
-    private Set<KielisyysDto> kielisyys = new HashSet<>();
+    private Set<KielisyysDto> kielisyys = null;
 
-    private Set<KansalaisuusDto> kansalaisuus = new HashSet<>();
+    private Set<KansalaisuusDto> kansalaisuus = null;
 
-    private Set<YhteystiedotRyhmaDto> yhteystiedotRyhma = new HashSet<>();
+    private Set<YhteystiedotRyhmaDto> yhteystiedotRyhma = null;
 
     private HenkiloTyyppi henkiloTyyppi;
 }

--- a/oppijanumerorekisteri-api/src/test/java/fi/vm/sade/oppijanumerorekisteri/validation/ValidateAtLeastOneNotNullValidatorTest.java
+++ b/oppijanumerorekisteri-api/src/test/java/fi/vm/sade/oppijanumerorekisteri/validation/ValidateAtLeastOneNotNullValidatorTest.java
@@ -16,13 +16,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
-import static org.mockito.Matchers.contains;
 import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
-import org.mockito.runners.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(SpringRunner.class)
 public class ValidateAtLeastOneNotNullValidatorTest {
 
     private ValidateAtLeastOneNotNullValidator validator;

--- a/oppijanumerorekisteri-api/src/test/java/fi/vm/sade/oppijanumerorekisteri/validation/ValidateAtLeastOneNotNullValidatorTest.java
+++ b/oppijanumerorekisteri-api/src/test/java/fi/vm/sade/oppijanumerorekisteri/validation/ValidateAtLeastOneNotNullValidatorTest.java
@@ -110,7 +110,7 @@ public class ValidateAtLeastOneNotNullValidatorTest {
     }
 
     @Test
-    public void isValidShouldReturnFalseWenAllNonNull() {
+    public void isValidShouldReturnFalseWhenAllNonNull() {
         List<String> fields = asList("stringValue", "integerValue");
         validator.initialize(createAnnotation(fields));
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceController.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceController.java
@@ -10,7 +10,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.validation.BindException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -145,7 +144,7 @@ public class Service2ServiceController {
             notes = "Päivittää kutsussa annettuun OID:n täsmäävän henkilön tiedot")
     @PreAuthorize("hasRole('APP_HENKILONHALLINTA_MUUTOSTIETOPALVELU')")
     @RequestMapping(value = "/henkilo/muutostiedot", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public HenkiloReadDto forceUpdateHenkilo(@Validated @RequestBody HenkiloUpdateDto henkiloUpdateDto) {
+    public HenkiloReadDto forceUpdateHenkilo(@Validated @RequestBody HenkiloForceUpdateDto henkiloUpdateDto) {
         return this.henkiloService.forceUpdateHenkilo(henkiloUpdateDto);
     }
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/DuplicateService.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/DuplicateService.java
@@ -1,0 +1,26 @@
+package fi.vm.sade.oppijanumerorekisteri.services;
+
+import fi.vm.sade.oppijanumerorekisteri.dto.HakemusDto;
+import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloDuplicateDto;
+import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloDuplikaattiCriteria;
+import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
+
+import java.util.List;
+
+public interface DuplicateService {
+    List<HenkiloDuplicateDto> findDuplicates(String oid);
+
+    List<HakemusDto> getApplications(String oid);
+
+    List<HenkiloDuplicateDto> getDuplikaatit(HenkiloDuplikaattiCriteria criteria);
+
+    List<String> linkHenkilos(String henkiloOid, List<String> similarHenkiloOids);
+
+    Henkilo determineMasterHenkilo(String henkiloOid, List<String> similarHenkiloOids);
+
+    boolean hasMoreThanOneIdentifiedHenkilo(List<Henkilo> henkilos);
+
+    boolean isHenkiloIdentified(Henkilo henkilo);
+
+    void unlinkHenkilo(String oid, String slaveOid);
+}

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/DuplicateService.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/DuplicateService.java
@@ -16,11 +16,5 @@ public interface DuplicateService {
 
     List<String> linkHenkilos(String henkiloOid, List<String> similarHenkiloOids);
 
-    Henkilo determineMasterHenkilo(String henkiloOid, List<String> similarHenkiloOids);
-
-    boolean hasMoreThanOneIdentifiedHenkilo(List<Henkilo> henkilos);
-
-    boolean isHenkiloIdentified(Henkilo henkilo);
-
     void unlinkHenkilo(String oid, String slaveOid);
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloService.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloService.java
@@ -7,6 +7,7 @@ import fi.vm.sade.oppijanumerorekisteri.dto.*;
 import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.repositories.criteria.HenkiloCriteria;
 import org.joda.time.DateTime;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
@@ -50,7 +51,7 @@ public interface HenkiloService {
 
     HenkiloUpdateDto updateHenkilo(HenkiloUpdateDto henkiloUpdateDto);
 
-    HenkiloReadDto forceUpdateHenkilo(HenkiloUpdateDto henkiloUpdateDto);
+    HenkiloReadDto forceUpdateHenkilo(HenkiloForceUpdateDto henkiloUpdateDto);
 
     HenkilonYhteystiedotViewDto getHenkiloYhteystiedot(String henkiloOid);
 
@@ -76,17 +77,7 @@ public interface HenkiloService {
 
     Henkilo update(Henkilo henkilo);
 
-    List<HenkiloReadDto> findSlavesByMasterOid(String oid);
-
-    List<HenkiloDuplicateDto> findDuplicates(String oid);
-
-    List<HakemusDto> getApplications(String oid);
-
-    List<HenkiloDuplicateDto> getDuplikaatit(HenkiloDuplikaattiCriteria criteria);
-
-    List<String> linkHenkilos(String masterOid, List<String> slaveOids);
-
-    void unlinkHenkilo(String oid, String slaveOid);
+    List<HenkiloReadDto> findSlavesByMasterOid(String masterOid);
 
     String getAsiointikieli(String oidHenkilo);
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/DuplicateServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/DuplicateServiceImpl.java
@@ -1,0 +1,219 @@
+package fi.vm.sade.oppijanumerorekisteri.services.impl;
+
+import fi.vm.sade.oppijanumerorekisteri.clients.AtaruClient;
+import fi.vm.sade.oppijanumerorekisteri.clients.HakuappClient;
+import fi.vm.sade.oppijanumerorekisteri.clients.KayttooikeusClient;
+import fi.vm.sade.oppijanumerorekisteri.dto.HakemusDto;
+import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloDuplicateDto;
+import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloDuplikaattiCriteria;
+import fi.vm.sade.oppijanumerorekisteri.exceptions.ForbiddenException;
+import fi.vm.sade.oppijanumerorekisteri.exceptions.NotFoundException;
+import fi.vm.sade.oppijanumerorekisteri.mappers.OrikaConfiguration;
+import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
+import fi.vm.sade.oppijanumerorekisteri.models.HenkiloViite;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloJpaRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloViiteRepository;
+import fi.vm.sade.oppijanumerorekisteri.services.DuplicateService;
+import fi.vm.sade.oppijanumerorekisteri.services.UserDetailsHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+@Service
+@RequiredArgsConstructor
+public class DuplicateServiceImpl implements DuplicateService {
+    private final HenkiloRepository henkiloDataRepository;
+    private final HenkiloViiteRepository henkiloViiteRepository;
+    private final HenkiloJpaRepository henkiloJpaRepository;
+    private final HakuappClient hakuappClient;
+    private final AtaruClient ataruClient;
+    private final UserDetailsHelper userDetailsHelper;
+    private final OrikaConfiguration mapper;
+    private final KayttooikeusClient kayttooikeusClient;
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<HenkiloDuplicateDto> findDuplicates(String oid) {
+        Henkilo henkilo = this.henkiloDataRepository.findByOidHenkilo(oid).orElseThrow( () -> new NotFoundException("User with oid " + oid + " was not found") );
+        HenkiloDuplikaattiCriteria criteria = new HenkiloDuplikaattiCriteria(henkilo.getEtunimet(), henkilo.getKutsumanimi(), henkilo.getSukunimi());
+        List<Henkilo> candidates = this.henkiloJpaRepository.findDuplikaatit(criteria).stream().filter(duplicate -> !duplicate.getOidHenkilo().equals(oid)).collect(toList());
+        return getHenkiloDuplicateDtoList(candidates);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<HakemusDto> getApplications(String oid) {
+        HashSet<String> oids = new HashSet<>(Arrays.asList(oid));
+        Map<String, List<HakemusDto>> hakuAppHakemukset = hakuappClient.fetchApplicationsByOid(oids);
+        Map<String, List<HakemusDto>> ataruHakemukset = ataruClient.fetchApplicationsByOid(oids);
+        List<HakemusDto> hakemukset = new ArrayList<>();
+        if(hakuAppHakemukset.get(oid) != null) {
+            hakemukset.addAll(hakuAppHakemukset.get(oid));
+        }
+        if(ataruHakemukset.get(oid) != null) {
+            hakemukset.addAll(ataruHakemukset.get(oid));
+        }
+        return hakemukset;
+    }
+
+    @Override
+    public List<HenkiloDuplicateDto> getDuplikaatit(HenkiloDuplikaattiCriteria criteria) {
+        List<Henkilo> henkilot = henkiloJpaRepository.findDuplikaatit(criteria);
+        return getHenkiloDuplicateDtoList(henkilot);
+    }
+
+    private List<HenkiloDuplicateDto> getHenkiloDuplicateDtoList(List<Henkilo> candidates) {
+        String kayttajaOid = this.userDetailsHelper.getCurrentUserOid();
+        List<HenkiloDuplicateDto> henkiloDuplicateDtos = this.mapper.mapAsList(candidates, HenkiloDuplicateDto.class)
+                .stream().filter(henkiloDuplicate -> !henkiloDuplicate.getOidHenkilo().equals(kayttajaOid)).collect(toList()); // remove current user from duplicate search results
+        Set<String> duplicateOids = henkiloDuplicateDtos.stream().map(HenkiloDuplicateDto::getOidHenkilo).collect(toSet());
+        Map<String, List<HakemusDto>> hakuAppHakemukset = hakuappClient.fetchApplicationsByOid(duplicateOids);
+        Map<String, List<HakemusDto>> ataruHakemukset = ataruClient.fetchApplicationsByOid(duplicateOids);
+
+        henkiloDuplicateDtos.forEach(duplicate -> {
+            String oidHenkilo = duplicate.getOidHenkilo();
+            List<HakemusDto> hakemusDtos = new ArrayList<>();
+            if (hakuAppHakemukset.get(oidHenkilo) != null) {
+                hakemusDtos.addAll(hakuAppHakemukset.get(oidHenkilo));
+            }
+            if (ataruHakemukset.get(oidHenkilo) != null) {
+                hakemusDtos.addAll(ataruHakemukset.get(oidHenkilo));
+            }
+            duplicate.setHakemukset(hakemusDtos);
+        });
+
+        return henkiloDuplicateDtos;
+    }
+
+
+
+    @Override
+    @Transactional
+    public List<String> linkHenkilos(String henkiloOid, List<String> similarHenkiloOids) {
+        Date modificationDate = new Date();
+        similarHenkiloOids = similarHenkiloOids.stream().filter( oid -> !henkiloOid.equals(oid)).distinct().collect(toList());
+
+        Henkilo master = determineMasterHenkilo(henkiloOid, similarHenkiloOids);
+        master.setPassivoitu(false);
+        master.setDuplicate(false);
+        master.setModified(modificationDate);
+
+        List<String> slaveOids = similarHenkiloOids;
+        if(!henkiloOid.equals(master.getOidHenkilo())) {
+            // If person changed, make the original one of the slaves
+            // (and if the resolved master was one of the original slaves, remove that):
+            slaveOids.remove(master.getOidHenkilo());
+            slaveOids.add(henkiloOid);
+        }
+
+        // If master previously was a slave, preserve the two-level hierarchy also in this way so that
+        // this new master will become the master of it's previous master (and its possible other slaves):
+        slaveOids.addAll(
+                this.henkiloViiteRepository.findBySlaveOid(master.getOidHenkilo())
+                        .stream()
+                        .map(HenkiloViite::getMasterOid).collect(toSet()));
+
+        for (String slaveOid : slaveOids) {
+            this.linkHenkilos(modificationDate, master, viite -> master.getOidHenkilo().equals(viite.getMasterOid()), slaveOid);
+        }
+
+        return slaveOids;
+    }
+
+    private void linkHenkilos(Date modificationDate,
+                              Henkilo master,
+                              java.util.function.Predicate<HenkiloViite> relatesToGivenMaster,
+                              String slaveOid) {
+        List<HenkiloViite> existingViittees = this.henkiloViiteRepository.findBySlaveOid(slaveOid);
+        existingViittees.stream().filter(relatesToGivenMaster.negate())
+                .forEach(viite -> {
+                    // If given slave already linked to another master, update the related (old) master
+                    this.henkiloDataRepository.findByOidHenkilo(viite.getMasterOid())
+                            .ifPresent( henkilo -> henkilo.setModified(modificationDate));
+                    // and remove this other viite:
+                    this.henkiloViiteRepository.delete(viite);
+                });
+
+        if (existingViittees.stream().anyMatch(relatesToGivenMaster)) {
+            // No need to add new viite (already linked to the given master):
+            return;
+        }
+
+        HenkiloViite viite = new HenkiloViite();
+        viite.setMasterOid(master.getOidHenkilo());
+        viite.setSlaveOid(slaveOid);
+        this.henkiloViiteRepository.save(viite);
+
+        Henkilo duplicateHenkilo = this.henkiloDataRepository.findByOidHenkilo(slaveOid)
+                .orElseThrow( () -> new NotFoundException("Henkilo not found with given oid " + slaveOid) );
+        duplicateHenkilo.setDuplicate(true);
+        duplicateHenkilo.setPassivoitu(true);
+        // Doesn't throw even if user doesn't exists in kayttooikeus-service
+        this.kayttooikeusClient.passivoiHenkilo(duplicateHenkilo.getOidHenkilo(), this.userDetailsHelper.getCurrentUserOid());
+        duplicateHenkilo.setModified(modificationDate);
+
+        // Preserve two-level hierarchy, re-link slave's slaves to new master
+        this.henkiloViiteRepository.findByMasterOid(slaveOid).forEach( slavesSlave -> {
+            if (slavesSlave.getSlaveOid().equals(master.getOidHenkilo())) {
+                this.henkiloViiteRepository.delete(slavesSlave);
+            } else {
+                Henkilo slaveSlaveHenkilo = this.henkiloDataRepository.findByOidHenkilo(slavesSlave.getSlaveOid())
+                        .orElseThrow( () -> new NotFoundException("Henkilo not found with given oid " + slavesSlave.getSlaveOid()));
+                slaveSlaveHenkilo.setModified(modificationDate);
+                slavesSlave.setMasterOid(master.getOidHenkilo());
+            }
+        });
+    }
+
+    @Override
+    public Henkilo determineMasterHenkilo(String henkiloOid, List<String> similarHenkiloOids) {
+        Henkilo originalMaster = this.henkiloDataRepository.findByOidHenkilo(henkiloOid)
+                .orElseThrow( () -> new NotFoundException("User with oid " + henkiloOid + " was not found"));
+        List<Henkilo> candidates = this.henkiloDataRepository.findByOidHenkiloIsIn(similarHenkiloOids);
+
+        /* Positively identified Henkilo MUST ALWAYS be the master
+         * and only one identified Henkilo can be in the similarHenkiloList/masterHenkilo
+         * since it would cause ambiguous behavior in linking
+         */
+        List<Henkilo> allHenkilos = new ArrayList<>(candidates);
+        allHenkilos.add(originalMaster);
+        if(hasMoreThanOneIdentifiedHenkilo(allHenkilos)) {
+            throw new ForbiddenException("More than one identified Henkilo");
+        }
+
+        // if there is one identified henkilo, set him as master - otherwise master will be the henkilo whos oid was given as first parameter
+        return candidates
+                .stream()
+                .reduce( originalMaster, (currentMaster, candidate) -> isHenkiloIdentified(candidate) ? candidate : currentMaster );
+    }
+
+    @Override
+    public boolean hasMoreThanOneIdentifiedHenkilo(List<Henkilo> henkilos) {
+        return henkilos.stream().filter(this::isHenkiloIdentified).count() > 1;
+    }
+
+    @Override
+    public boolean isHenkiloIdentified(Henkilo henkilo) {
+        return henkilo.isYksiloity() || henkilo.isYksiloityVTJ() || henkilo.getHetu() != null;
+    }
+
+    @Override
+    @Transactional
+    public void unlinkHenkilo(String oid, String slaveOid) {
+        Date modificationDate = new Date();
+        Henkilo slave = this.henkiloDataRepository.findByOidHenkilo(slaveOid)
+                .orElseThrow( () -> new NotFoundException("User with oid " + oid + " was not found"));
+        slave.setDuplicate(false);
+        slave.setPassivoitu(false);
+        slave.setModified(modificationDate);
+        this.henkiloViiteRepository.removeByMasterOidAndSlaveOid(oid, slaveOid);
+    }
+
+}

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
@@ -1,6 +1,5 @@
 package fi.vm.sade.oppijanumerorekisteri.services.impl;
 
-import com.google.common.collect.Sets;
 import fi.vm.sade.oppijanumerorekisteri.clients.AtaruClient;
 import fi.vm.sade.oppijanumerorekisteri.clients.HakuappClient;
 import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloYhteystietoDto;
@@ -36,7 +35,6 @@ import org.springframework.validation.BindException;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.util.*;
 import static java.util.Collections.emptyList;
 import java.util.stream.Collectors;
@@ -73,8 +71,6 @@ public class HenkiloServiceImpl implements HenkiloService {
     private final OppijanumerorekisteriProperties oppijanumerorekisteriProperties;
 
     private final KayttooikeusClient kayttooikeusClient;
-    private final HakuappClient hakuappClient;
-    private final AtaruClient ataruClient;
 
 
 
@@ -362,16 +358,15 @@ public class HenkiloServiceImpl implements HenkiloService {
     // Values can be saved overwritten and Hetu can be changed even if isYksiloityVTJ() is true.
     @Override
     @Transactional
-    public HenkiloReadDto forceUpdateHenkilo(HenkiloUpdateDto henkiloUpdateDto) {
+    public HenkiloReadDto forceUpdateHenkilo(HenkiloForceUpdateDto henkiloUpdateDto) {
         BindException errors = new BindException(henkiloUpdateDto, "henkiloUpdateDto");
         this.henkiloUpdatePostValidator.validateWithoutHetu(henkiloUpdateDto, errors);
         if (errors.hasErrors()) {
             throw new UnprocessableEntityException(errors);
         }
 
-        Henkilo henkiloSaved = this.henkiloDataRepository.findByOidHenkiloIsIn(
-                Lists.newArrayList(henkiloUpdateDto.getOidHenkilo()))
-                .stream().findFirst().orElseThrow(NotFoundException::new);
+        Henkilo henkiloSaved = this.henkiloDataRepository.findByOidHenkilo(henkiloUpdateDto.getOidHenkilo())
+                .orElseThrow(() -> new NotFoundException("Could not find henkilo " + henkiloUpdateDto.getOidHenkilo()));
 
         henkiloUpdateSetReusableFields(henkiloUpdateDto, henkiloSaved);
 
@@ -629,181 +624,6 @@ public class HenkiloServiceImpl implements HenkiloService {
     public List<HenkiloReadDto> findSlavesByMasterOid(String masterOid) {
         List<Henkilo> henkilos = this.henkiloJpaRepository.findSlavesByMasterOid(masterOid);
         return henkilos.stream().map( h -> mapper.map(h, HenkiloReadDto.class)).collect(Collectors.toList());
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<HenkiloDuplicateDto> findDuplicates(String oid) {
-        Henkilo henkilo = this.henkiloDataRepository.findByOidHenkilo(oid).orElseThrow( () -> new NotFoundException("User with oid " + oid + " was not found") );
-        HenkiloDuplikaattiCriteria criteria = new HenkiloDuplikaattiCriteria(henkilo.getEtunimet(), henkilo.getKutsumanimi(), henkilo.getSukunimi());
-        List<Henkilo> candidates = this.henkiloJpaRepository.findDuplikaatit(criteria).stream().filter(duplicate -> !duplicate.getOidHenkilo().equals(oid)).collect(toList());
-        return getHenkiloDuplicateDtoList(candidates);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<HakemusDto> getApplications(String oid) {
-        HashSet<String> oids = new HashSet<>(Arrays.asList(oid));
-        Map<String, List<HakemusDto>> hakuAppHakemukset = hakuappClient.fetchApplicationsByOid(oids);
-        Map<String, List<HakemusDto>> ataruHakemukset = ataruClient.fetchApplicationsByOid(oids);
-        List<HakemusDto> hakemukset = new ArrayList<>();
-        if(hakuAppHakemukset.get(oid) != null) {
-            hakemukset.addAll(hakuAppHakemukset.get(oid));
-        }
-        if(ataruHakemukset.get(oid) != null) {
-            hakemukset.addAll(ataruHakemukset.get(oid));
-        }
-        return hakemukset;
-    }
-
-    @Override
-    public List<HenkiloDuplicateDto> getDuplikaatit(HenkiloDuplikaattiCriteria criteria) {
-        List<Henkilo> henkilot = henkiloJpaRepository.findDuplikaatit(criteria);
-        return getHenkiloDuplicateDtoList(henkilot);
-    }
-
-    private List<HenkiloDuplicateDto> getHenkiloDuplicateDtoList(List<Henkilo> candidates) {
-        String kayttajaOid = this.userDetailsHelper.getCurrentUserOid();
-        List<HenkiloDuplicateDto> henkiloDuplicateDtos = this.mapper.mapAsList(candidates, HenkiloDuplicateDto.class)
-                .stream().filter(henkiloDuplicate -> !henkiloDuplicate.getOidHenkilo().equals(kayttajaOid)).collect(toList()); // remove current user from duplicate search results
-        Set<String> duplicateOids = henkiloDuplicateDtos.stream().map(HenkiloDuplicateDto::getOidHenkilo).collect(toSet());
-        Map<String, List<HakemusDto>> hakuAppHakemukset = hakuappClient.fetchApplicationsByOid(duplicateOids);
-        Map<String, List<HakemusDto>> ataruHakemukset = ataruClient.fetchApplicationsByOid(duplicateOids);
-
-        henkiloDuplicateDtos.forEach(duplicate -> {
-            String oidHenkilo = duplicate.getOidHenkilo();
-            List<HakemusDto> hakemusDtos = new ArrayList<>();
-            if(hakuAppHakemukset.get(oidHenkilo) != null) {
-                hakemusDtos.addAll(hakuAppHakemukset.get(oidHenkilo));
-            }
-            if(ataruHakemukset.get(oidHenkilo) != null) {
-                hakemusDtos.addAll(ataruHakemukset.get(oidHenkilo));
-            }
-            duplicate.setHakemukset(hakemusDtos);
-        });
-
-        return henkiloDuplicateDtos;
-    }
-
-
-
-    @Override
-    @Transactional
-    public List<String> linkHenkilos(String henkiloOid, List<String> similarHenkiloOids) {
-        Date modificationDate = new Date();
-        similarHenkiloOids = similarHenkiloOids.stream().filter( oid -> !henkiloOid.equals(oid)).distinct().collect(toList());
-
-        Henkilo master = determineMasterHenkilo(henkiloOid, similarHenkiloOids);
-        master.setPassivoitu(false);
-        master.setDuplicate(false);
-        master.setModified(modificationDate);
-
-        List<String> slaveOids = similarHenkiloOids;
-        if(!henkiloOid.equals(master.getOidHenkilo())) {
-            // If person changed, make the original one of the slaves
-            // (and if the resolved master was one of the original slaves, remove that):
-            slaveOids.remove(master.getOidHenkilo());
-            slaveOids.add(henkiloOid);
-        }
-
-        // If master previously was a slave, preserve the two-level hierarchy also in this way so that
-        // this new master will become the master of it's previous master (and its possible other slaves):
-        slaveOids.addAll(
-                this.henkiloViiteRepository.findBySlaveOid(master.getOidHenkilo())
-                .stream()
-                .map(HenkiloViite::getMasterOid).collect(toSet()));
-
-        for (String slaveOid : slaveOids) {
-            this.linkHenkilos(modificationDate, master, viite -> master.getOidHenkilo().equals(viite.getMasterOid()), slaveOid);
-        }
-
-        return slaveOids;
-    }
-
-    private void linkHenkilos(Date modificationDate,
-                              Henkilo master,
-                              java.util.function.Predicate<HenkiloViite> relatesToGivenMaster,
-                              String slaveOid) {
-        List<HenkiloViite> existingViittees = this.henkiloViiteRepository.findBySlaveOid(slaveOid);
-        existingViittees.stream().filter(relatesToGivenMaster.negate())
-                .forEach(viite -> {
-                    // If given slave already linked to another master, update the related (old) master
-                    this.henkiloDataRepository.findByOidHenkilo(viite.getMasterOid())
-                            .ifPresent( henkilo -> henkilo.setModified(modificationDate));
-                    // and remove this other viite:
-                    this.henkiloViiteRepository.delete(viite);
-                });
-
-        if (existingViittees.stream().anyMatch(relatesToGivenMaster)) {
-            // No need to add new viite (already linked to the given master):
-            return;
-        }
-
-        HenkiloViite viite = new HenkiloViite();
-        viite.setMasterOid(master.getOidHenkilo());
-        viite.setSlaveOid(slaveOid);
-        this.henkiloViiteRepository.save(viite);
-
-        Henkilo duplicateHenkilo = this.henkiloDataRepository.findByOidHenkilo(slaveOid)
-                .orElseThrow( () -> new NotFoundException("Henkilo not found with given oid " + slaveOid) );
-        duplicateHenkilo.setDuplicate(true);
-        duplicateHenkilo.setPassivoitu(true);
-        // Doesn't throw even if user doesn't exists in kayttooikeus-service
-        this.kayttooikeusClient.passivoiHenkilo(duplicateHenkilo.getOidHenkilo(), this.userDetailsHelper.getCurrentUserOid());
-        duplicateHenkilo.setModified(modificationDate);
-
-        // Preserve two-level hierarchy, re-link slave's slaves to new master
-        this.henkiloViiteRepository.findByMasterOid(slaveOid).forEach( slavesSlave -> {
-            if (slavesSlave.getSlaveOid().equals(master.getOidHenkilo())) {
-                this.henkiloViiteRepository.delete(slavesSlave);
-            } else {
-                Henkilo slaveSlaveHenkilo = this.henkiloDataRepository.findByOidHenkilo(slavesSlave.getSlaveOid())
-                        .orElseThrow( () -> new NotFoundException("Henkilo not found with given oid " + slavesSlave.getSlaveOid()));
-                slaveSlaveHenkilo.setModified(modificationDate);
-                slavesSlave.setMasterOid(master.getOidHenkilo());
-            }
-        });
-    }
-
-    private Henkilo determineMasterHenkilo(String henkiloOid, List<String> similarHenkiloOids) {
-        Henkilo originalMaster = this.henkiloDataRepository.findByOidHenkilo(henkiloOid)
-                .orElseThrow( () -> new NotFoundException("User with oid " + henkiloOid + " was not found"));
-        List<Henkilo> candidates = this.henkiloDataRepository.findByOidHenkiloIsIn(similarHenkiloOids);
-
-        /* Positively identified Henkilo MUST ALWAYS be the master
-         * and only one identified Henkilo can be in the similarHenkiloList/masterHenkilo
-         * since it would cause ambiguous behavior in linking
-         */
-        List<Henkilo> allHenkilos = new ArrayList<>(candidates);
-        allHenkilos.add(originalMaster);
-        if(hasMoreThanOneIdentifiedHenkilo(allHenkilos)) {
-            throw new ForbiddenException("More than one identified Henkilo");
-        }
-
-        // if there is one identified henkilo, set him as master - otherwise master will be the henkilo whos oid was given as first parameter
-        return candidates
-                .stream()
-                .reduce( originalMaster, (currentMaster, candidate) -> isHenkiloIdentified(candidate) ? candidate : currentMaster );
-    }
-
-    private boolean hasMoreThanOneIdentifiedHenkilo(List<Henkilo> henkilos) {
-        return henkilos.stream().filter(this::isHenkiloIdentified).count() > 1;
-    }
-
-    private boolean isHenkiloIdentified(Henkilo henkilo) {
-        return henkilo.isYksiloity() || henkilo.isYksiloityVTJ() || henkilo.getHetu() != null;
-    }
-
-    @Override
-    @Transactional
-    public void unlinkHenkilo(String oid, String slaveOid) {
-        Date modificationDate = new Date();
-        Henkilo slave = this.henkiloDataRepository.findByOidHenkilo(slaveOid)
-                .orElseThrow( () -> new NotFoundException("User with oid " + oid + " was not found"));
-        slave.setDuplicate(false);
-        slave.setPassivoitu(false);
-        slave.setModified(modificationDate);
-        this.henkiloViiteRepository.removeByMasterOidAndSlaveOid(oid, slaveOid);
     }
 
     @Override

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceImpl.java
@@ -12,6 +12,7 @@ import fi.vm.sade.oppijanumerorekisteri.models.Identification;
 import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloJpaRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.YksilointitietoRepository;
+import fi.vm.sade.oppijanumerorekisteri.services.DuplicateService;
 import fi.vm.sade.oppijanumerorekisteri.services.HenkiloService;
 import fi.vm.sade.oppijanumerorekisteri.services.IdentificationService;
 
@@ -38,6 +39,7 @@ public class IdentificationServiceImpl implements IdentificationService {
 
     private final YksilointiService yksilointiService;
     private final HenkiloService henkiloService;
+    private final DuplicateService duplicateService;
 
     private Henkilo getHenkiloByOid(String oid) {
         return henkiloRepository.findByOidHenkilo(oid).orElseThrow(()
@@ -110,7 +112,7 @@ public class IdentificationServiceImpl implements IdentificationService {
                     oppijaWithSameHetu.setHetu(null);
                     // Hetu is unique so we need to flush when moving it
                     this.henkiloRepository.saveAndFlush(oppijaWithSameHetu);
-                    this.henkiloService.linkHenkilos(oidHenkilo, Lists.newArrayList(oppijaWithSameHetu.getOidHenkilo()));
+                    this.duplicateService.linkHenkilos(oidHenkilo, Lists.newArrayList(oppijaWithSameHetu.getOidHenkilo()));
                 });
 
         // No current hetu and hetu not already used => set hetu

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/controllers/HenkiloControllerTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/controllers/HenkiloControllerTest.java
@@ -4,11 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.vm.sade.oppijanumerorekisteri.OppijanumerorekisteriServiceApplication;
 import fi.vm.sade.oppijanumerorekisteri.dto.*;
 import fi.vm.sade.oppijanumerorekisteri.exceptions.NotFoundException;
-import fi.vm.sade.oppijanumerorekisteri.services.YksilointiService;
+import fi.vm.sade.oppijanumerorekisteri.services.*;
 import fi.vm.sade.oppijanumerorekisteri.utils.DtoUtils;
-import fi.vm.sade.oppijanumerorekisteri.services.HenkiloService;
-import fi.vm.sade.oppijanumerorekisteri.services.IdentificationService;
-import fi.vm.sade.oppijanumerorekisteri.services.PermissionChecker;
 import fi.vm.sade.oppijanumerorekisteri.validators.HenkiloUpdatePostValidator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,8 +31,8 @@ import java.util.Date;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,6 +46,9 @@ public class HenkiloControllerTest {
 
     @MockBean
     private HenkiloService henkiloService;
+
+    @MockBean
+    private DuplicateService duplicateService;
 
     @MockBean
     private IdentificationService identificationService;

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceControllerTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceControllerTest.java
@@ -27,8 +27,8 @@ import java.util.HashSet;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloServiceTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloServiceTest.java
@@ -1,7 +1,5 @@
 package fi.vm.sade.oppijanumerorekisteri.services;
 
-
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.querydsl.core.types.Predicate;
 import fi.vm.sade.kayttooikeus.dto.KayttooikeudetDto;
@@ -9,19 +7,19 @@ import fi.vm.sade.oppijanumerorekisteri.clients.AtaruClient;
 import fi.vm.sade.oppijanumerorekisteri.clients.HakuappClient;
 import fi.vm.sade.oppijanumerorekisteri.clients.KayttooikeusClient;
 import fi.vm.sade.oppijanumerorekisteri.configurations.properties.OppijanumerorekisteriProperties;
-import fi.vm.sade.oppijanumerorekisteri.mappers.OrikaConfiguration;
 import fi.vm.sade.oppijanumerorekisteri.dto.*;
 import fi.vm.sade.oppijanumerorekisteri.exceptions.NotFoundException;
+import fi.vm.sade.oppijanumerorekisteri.mappers.EntityUtils;
+import fi.vm.sade.oppijanumerorekisteri.mappers.OrikaConfiguration;
+import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.models.YhteystiedotRyhma;
 import fi.vm.sade.oppijanumerorekisteri.repositories.*;
 import fi.vm.sade.oppijanumerorekisteri.repositories.criteria.HenkiloCriteria;
-import fi.vm.sade.oppijanumerorekisteri.utils.DtoUtils;
-import fi.vm.sade.oppijanumerorekisteri.mappers.EntityUtils;
-import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.repositories.criteria.YhteystietoCriteria;
 import fi.vm.sade.oppijanumerorekisteri.repositories.dto.YhteystietoHakuDto;
 import fi.vm.sade.oppijanumerorekisteri.services.convert.YhteystietoConverter;
 import fi.vm.sade.oppijanumerorekisteri.services.impl.HenkiloServiceImpl;
+import fi.vm.sade.oppijanumerorekisteri.utils.DtoUtils;
 import fi.vm.sade.oppijanumerorekisteri.validators.HenkiloCreatePostValidator;
 import fi.vm.sade.oppijanumerorekisteri.validators.HenkiloUpdatePostValidator;
 import org.junit.Before;
@@ -34,19 +32,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static fi.vm.sade.oppijanumerorekisteri.dto.YhteystietoTyyppi.*;
-import java.time.LocalDate;
-import java.time.Month;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
-
-import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toList;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -93,7 +87,7 @@ public class HenkiloServiceTest {
         this.service = spy(new HenkiloServiceImpl(this.henkiloJpaRepositoryMock, henkiloDataRepositoryMock, henkiloViiteRepositoryMock,
                 this.kielisyysRepositoryMock, this.kansalaisuusRepositoryMock, new YhteystietoConverter(), mapper, mockOidGenerator,
                 this.userDetailsHelperMock, this.permissionCheckerMock, henkiloUpdatePostValidatorMock,
-                henkiloCreatePostValidatorMock, oppijanumerorekisteriProperties, kayttooikeusClient, hakuappClient, ataruClient));
+                henkiloCreatePostValidatorMock, oppijanumerorekisteriProperties, kayttooikeusClient));
     }
 
     @Test
@@ -635,45 +629,5 @@ public class HenkiloServiceTest {
         Henkilo saved = argumentCaptor.getValue();
         assertThat(saved.getPassinumerot()).containsExactly("passi123");
     }
-
-    @Test
-    public void getHenkiloDuplicateDtoListShouldReturnApplicationsFromAtaruAndHakuApp() {
-        Henkilo henkilo1 = EntityUtils.createHenkilo("arpa noppa", "arpa", "kuutio", "hetu", "1.2.3.4.5", false, HenkiloTyyppi.OPPIJA, "fi", "FI", "2.3.34.5", new Date(), new Date(), "2.3.34.5", "arvo");
-        Henkilo henkilo2 = EntityUtils.createHenkilo("arpa2 noppa2", "arpa2", "kuutio2", "hetu2", "1.2.3.4.6", false, HenkiloTyyppi.OPPIJA, "fi", "FI", "2.3.34.5", new Date(), new Date(), "2.3.34.5", "arvo");
-        Henkilo henkilo3 = EntityUtils.createHenkilo("arpa3 noppa3", "arpa3", "kuutio3", "hetu3", "1.3.3.4.7", false, HenkiloTyyppi.OPPIJA, "fi", "FI", "2.3.34.56", new Date(), new Date(), "2.3.34.5", "arvo");
-        List<Henkilo> henkilos = Arrays.asList(henkilo1, henkilo2, henkilo3);
-        given(this.userDetailsHelperMock.getCurrentUserOid()).willReturn("1.2.3.4.5");
-        HashMap<String, Object> hakemus1 = new HashMap<>();
-        hakemus1.put("service", "ataru");
-        HashMap<String, Object> hakemus2 = new HashMap<>();
-        hakemus2.put("service", "haku-app");
-
-        HakemusDto hakemusDto1 = new HakemusDto(hakemus1);
-        HakemusDto hakemusDto2 = new HakemusDto(hakemus2);
-
-        HashMap<String, List<HakemusDto>> ataruApplications = new HashMap<String, List<HakemusDto>>() { { put("1.2.3.4.6", Arrays.asList(hakemusDto1)); }; };
-        HashMap<String, List<HakemusDto>> hakuAppApplications = new HashMap<String, List<HakemusDto>>() { { put("1.3.3.4.7", Arrays.asList(hakemusDto2)); put("1.2.3.4.6", Arrays.asList(hakemusDto2)); }; };
-
-        hakuAppApplications.put("1.3.3.4.7", Arrays.asList(hakemusDto2));
-
-        given(this.ataruClient.fetchApplicationsByOid(any())).willReturn(ataruApplications);
-        given(this.hakuappClient.fetchApplicationsByOid(any())).willReturn(hakuAppApplications);
-
-        List<HenkiloDuplicateDto> duplicates = ReflectionTestUtils.invokeMethod(service, "getHenkiloDuplicateDtoList", henkilos);
-
-        assertThat(duplicates.size()).isEqualTo(2); // filter current user
-        HenkiloDuplicateDto henkiloDuplicateDto2 = duplicates.get(0);
-        assertThat(henkiloDuplicateDto2.getHakemukset().size()).isEqualTo(2);
-        assertThat(henkiloDuplicateDto2.getHakemukset()).contains(hakemusDto1);
-        assertThat(henkiloDuplicateDto2.getHakemukset()).contains(hakemusDto2);
-
-        HenkiloDuplicateDto henkiloDuplicateDto3 = duplicates.get(1);
-        assertThat(henkiloDuplicateDto3.getHakemukset().size()).isEqualTo(1);
-        assertThat(henkiloDuplicateDto3.getHakemukset()).contains(hakemusDto2);
-
-
-    }
-
-
 
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/PermissionCheckerTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/PermissionCheckerTest.java
@@ -18,11 +18,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyListOf;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.anySetOf;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +56,7 @@ public class PermissionCheckerTest {
     @WithMockUser(value = "1.2.3.4.5", roles = {"USER"})
     public void isAllowedToAccessPersonFromKayttooikeusService() throws Exception {
         given(this.kayttooikeusClient.checkUserPermissionToUser(eq("1.2.3.4.5"), eq("1.2.3.4.0"),
-                anyListOf(String.class), eq(null), anySetOf(String.class)))
+                anyList(), eq(null), anySet()))
                 .willReturn(true);
         boolean hasAccess = this.permissionChecker
                 .isAllowedToAccessPerson("1.2.3.4.0", Lists.newArrayList(), null);
@@ -71,7 +67,7 @@ public class PermissionCheckerTest {
     @WithMockUser(value = "1.2.3.4.5", roles = {"USER"})
     public void isAllowedToAccessPersonNot() throws Exception {
         given(this.kayttooikeusClient.checkUserPermissionToUser(eq("1.2.3.4.5"), eq("1.2.3.4.0"),
-                anyListOf(String.class), eq(null), anySetOf(String.class)))
+                anyList(), eq(null), anySet()))
                 .willReturn(false);
         boolean hasAccess = this.permissionChecker
                 .isAllowedToAccessPerson("1.2.3.4.0", Lists.newArrayList(), null);

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/DuplicateServiceImplTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/DuplicateServiceImplTest.java
@@ -1,0 +1,103 @@
+package fi.vm.sade.oppijanumerorekisteri.services.impl;
+
+import fi.vm.sade.oppijanumerorekisteri.clients.AtaruClient;
+import fi.vm.sade.oppijanumerorekisteri.clients.HakuappClient;
+import fi.vm.sade.oppijanumerorekisteri.clients.KayttooikeusClient;
+import fi.vm.sade.oppijanumerorekisteri.dto.HakemusDto;
+import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloDuplicateDto;
+import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloTyyppi;
+import fi.vm.sade.oppijanumerorekisteri.mappers.EntityUtils;
+import fi.vm.sade.oppijanumerorekisteri.mappers.OrikaConfiguration;
+import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloJpaRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloViiteRepository;
+import fi.vm.sade.oppijanumerorekisteri.services.DuplicateService;
+import fi.vm.sade.oppijanumerorekisteri.services.UserDetailsHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {OrikaConfiguration.class, DuplicateServiceImpl.class}, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class DuplicateServiceImplTest {
+    @Autowired
+    private OrikaConfiguration mapper;
+
+    @Autowired
+    private DuplicateService duplicateService;
+
+    @MockBean
+    private AtaruClient ataruClient;
+
+    @MockBean
+    private HakuappClient hakuappClient;
+
+    @MockBean
+    private UserDetailsHelper userDetailsHelper;
+
+    @MockBean
+    private HenkiloRepository henkiloRepository;
+
+    @MockBean
+    private HenkiloViiteRepository HenkiloViiteRepository;
+
+    @MockBean
+    private HenkiloJpaRepository henkiloJpaRepository;
+
+    @MockBean
+    private KayttooikeusClient kayttooikeusClient;
+
+    @Test
+    public void getHenkiloDuplicateDtoListShouldReturnApplicationsFromAtaruAndHakuApp() {
+        Henkilo henkilo1 = EntityUtils.createHenkilo("arpa noppa", "arpa", "kuutio", "hetu", "1.2.3.4.5", false, HenkiloTyyppi.OPPIJA, "fi", "FI", "2.3.34.5", new Date(), new Date(), "2.3.34.5", "arvo");
+        Henkilo henkilo2 = EntityUtils.createHenkilo("arpa2 noppa2", "arpa2", "kuutio2", "hetu2", "1.2.3.4.6", false, HenkiloTyyppi.OPPIJA, "fi", "FI", "2.3.34.5", new Date(), new Date(), "2.3.34.5", "arvo");
+        Henkilo henkilo3 = EntityUtils.createHenkilo("arpa3 noppa3", "arpa3", "kuutio3", "hetu3", "1.3.3.4.7", false, HenkiloTyyppi.OPPIJA, "fi", "FI", "2.3.34.56", new Date(), new Date(), "2.3.34.5", "arvo");
+        List<Henkilo> henkilos = Arrays.asList(henkilo1, henkilo2, henkilo3);
+        given(this.userDetailsHelper.getCurrentUserOid()).willReturn("1.2.3.4.5");
+        HashMap<String, Object> hakemus1 = new HashMap<>();
+        hakemus1.put("service", "ataru");
+        HashMap<String, Object> hakemus2 = new HashMap<>();
+        hakemus2.put("service", "haku-app");
+
+        HakemusDto hakemusDto1 = new HakemusDto(hakemus1);
+        HakemusDto hakemusDto2 = new HakemusDto(hakemus2);
+
+        HashMap<String, List<HakemusDto>> ataruApplications = new HashMap<String, List<HakemusDto>>() { { put("1.2.3.4.6", Arrays.asList(hakemusDto1)); }; };
+        HashMap<String, List<HakemusDto>> hakuAppApplications = new HashMap<String, List<HakemusDto>>() { { put("1.3.3.4.7", Arrays.asList(hakemusDto2)); put("1.2.3.4.6", Arrays.asList(hakemusDto2)); }; };
+
+        hakuAppApplications.put("1.3.3.4.7", Arrays.asList(hakemusDto2));
+
+        given(this.ataruClient.fetchApplicationsByOid(any())).willReturn(ataruApplications);
+        given(this.hakuappClient.fetchApplicationsByOid(any())).willReturn(hakuAppApplications);
+
+        List<HenkiloDuplicateDto> duplicates = ReflectionTestUtils.invokeMethod(duplicateService, "getHenkiloDuplicateDtoList", henkilos);
+
+        assertThat(duplicates.size()).isEqualTo(2); // filter current user
+        HenkiloDuplicateDto henkiloDuplicateDto2 = duplicates.get(0);
+        assertThat(henkiloDuplicateDto2.getHakemukset().size()).isEqualTo(2);
+        assertThat(henkiloDuplicateDto2.getHakemukset()).contains(hakemusDto1);
+        assertThat(henkiloDuplicateDto2.getHakemukset()).contains(hakemusDto2);
+
+        HenkiloDuplicateDto henkiloDuplicateDto3 = duplicates.get(1);
+        assertThat(henkiloDuplicateDto3.getHakemukset().size()).isEqualTo(1);
+        assertThat(henkiloDuplicateDto3.getHakemukset()).contains(hakemusDto2);
+
+
+    }
+
+
+}

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImplTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImplTest.java
@@ -98,7 +98,7 @@ public class HenkiloServiceImplTest {
         impl = new HenkiloServiceImpl(henkiloJpaRepository, henkiloRepository, henkiloViiteRepository,
                 kielisyysRepository, kansalaisuusRepository, yhteystietoConverter, orikaConfiguration, oidGenerator,
                 userDetailsHelper,  permissionChecker, henkiloUpdatePostValidator, henkiloCreatePostValidator,
-                oppijanumerorekisteriProperties, kayttooikeusClient, hakuappClient, ataruClient);
+                oppijanumerorekisteriProperties, kayttooikeusClient);
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTest.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.*;
 
 // Non-transactional in order to emulate how the real method call works. Thus db is not rolled back after tests.
 // See IdentificationServiceIntegrationTest2 if you want to add more tests.
@@ -61,7 +63,7 @@ public class IdentificationServiceIntegrationTest {
 
     @Test
     public void identifyHenkilos() {
-        @SuppressWarnings("unchedked")
+        @SuppressWarnings("unchecked")
         List<Henkilo> unidentifiedHenkilos = this.entityManager
                 .createNativeQuery("SELECT * FROM henkilo", Henkilo.class).getResultList();
 

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KoodiValidatorTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KoodiValidatorTest.java
@@ -13,16 +13,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.validation.Errors;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(SpringRunner.class)
 public class KoodiValidatorTest {
 
     private KoodiValidator koodistoValidator;


### PR DESCRIPTION
- Lisää muutostietopalvelun henkilöpäivitysrajapintaan uusi dto
- Siirtää HenkiloService:stä duplikaattien käsittelyn DuplicateServiceen (henkilöservicessä ~800 riviä koodia)