### PR TITLE
Kjhh 1285 kutsumanimivalidointi

### DIFF
--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
@@ -3,8 +3,14 @@ package fi.vm.sade.oppijanumerorekisteri.validators;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class KutsumanimiValidator {
@@ -17,29 +23,27 @@ public final class KutsumanimiValidator {
     }
 
     public boolean isValid(String kutsumanimi) {
+        String kutsumanimiLowerCase = kutsumanimi.toLowerCase();
 
-        kutsumanimi = kutsumanimi.toLowerCase();
-        if(Arrays.asList(etunimet.split(" ")).contains(kutsumanimi) == true) {
-            return true;
-        }
-
-        int beginIndex = etunimet.indexOf(kutsumanimi);
-        if (beginIndex == -1) {
-            return false;
-        }
-        // tarkistetaan että molemmin puolin nimeä löytyy jokin sallittu välimerkki
-        if (beginIndex > 0) {
-            if (!valimerkit.contains(etunimet.charAt(beginIndex - 1))) {
-                return false;
-            }
-        }
-        int endIndex = beginIndex + kutsumanimi.length();
-        if (endIndex < etunimet.length()) {
-            if (!valimerkit.contains(etunimet.charAt(endIndex))) {
-                return false;
-            }
-        }
-        return true;
+        // e.g. "arpa-noppa kuutio" => "arpa-noppa" "kuutio"
+        List<String> separatedByWhitespace = Arrays.stream(this.etunimet.split(" "))
+                .map(String::trim)
+                .collect(toList());
+        // e.g. "arpa-kuutio" => "arpa" "kuutio"
+        Set<String> separatedByDash = separatedByWhitespace.stream()
+                .filter(etunimi -> etunimi.contains("-"))
+                .flatMap(etunimi -> Arrays.stream(etunimi.split("-")))
+                .collect(toSet());
+        // e.g. "arpa noppa kuutio" "arpa noppa" "noppa kuutio"
+        Set<String> permutationsOfWhitespaceSeparation = separatedByWhitespace
+                .subList(0, separatedByWhitespace.size()-1).stream()
+                .map(etunimi -> etunimi + " " + separatedByWhitespace.get(separatedByWhitespace.indexOf(etunimi)+1))
+                .collect(Collectors.toSet());
+        // Compare all valid cases
+        return Stream.of(separatedByWhitespace, separatedByDash, permutationsOfWhitespaceSeparation)
+                .flatMap(Collection::stream)
+                .map(String::toLowerCase)
+                .anyMatch(etunimi -> etunimi.equals(kutsumanimiLowerCase));
     }
 
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
@@ -21,12 +21,7 @@ public final class KutsumanimiValidator {
         List<String> separatedByWhitespace = Arrays.stream(this.etunimet.split(" "))
                 .map(String::trim)
                 .collect(toList());
-        // e.g. "arpa-kuutio" => "arpa" "kuutio"
-        List<String> separatedByDash = separatedByWhitespace.stream()
-                .filter(etunimi -> etunimi.contains("-"))
-                .flatMap(etunimi -> Arrays.stream(etunimi.split("-")))
-                .collect(toList());
-        // e.g. "arpa-tupla noppa kuutio" "arpa-tupla noppa" "noppa kuutio" "arpa-tupla noppa kuutio"
+        // e.g. "arpa-tupla noppa kuutio" => "arpa-tupla" "noppa" "kuutio" "arpa-tupla noppa" "noppa kuutio" "arpa-tupla noppa kuutio"
         Set<String> subsequentPairs = separatedByWhitespace.stream()
                 .flatMap(etunimi -> this.getStream(separatedByWhitespace, etunimi))
                 .collect(Collectors.toSet());
@@ -38,7 +33,7 @@ public final class KutsumanimiValidator {
                 .flatMap(etunimi -> this.getStream(withoutDashes, etunimi))
                 .collect(Collectors.toSet());
         // Compare all valid cases
-        return Stream.of(separatedByWhitespace, separatedByDash, subsequentPairs, subsequentWithoutDash)
+        return Stream.of(separatedByWhitespace, subsequentPairs, subsequentWithoutDash)
                 .flatMap(Collection::stream)
                 .map(String::toLowerCase)
                 .distinct()
@@ -50,7 +45,7 @@ public final class KutsumanimiValidator {
         int lastIndex = separatedByWhitespace.size();
         Set<String> set = new HashSet<>();
         //
-        for (int tupleSize = 2; tupleSize <= lastIndex; tupleSize++) {
+        for (int tupleSize = 1; tupleSize <= lastIndex; tupleSize++) {
             for (int i = currentIndex; i <= lastIndex-tupleSize; i++) {
                 String flatSet = separatedByWhitespace.subList(i, i + tupleSize).stream()
                         .reduce((x, y) -> x + " " + y)

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
@@ -8,49 +8,49 @@ import static java.util.stream.Collectors.toList;
 
 public final class KutsumanimiValidator {
 
-    private final String etunimet;
+    private final List<String> basicDataSeparatedByWhitespace;
+    private final List<String> basicDataSeparatedByWhitespaceAndDashes;
 
     public KutsumanimiValidator(String etunimet) {
-        this.etunimet = etunimet.toLowerCase();
+        String etunimetLowercase = etunimet.toLowerCase();
+        // Basic set
+        this.basicDataSeparatedByWhitespace = Arrays.stream(etunimetLowercase.split(" "))
+                .map(String::trim)
+                .collect(toList());
+        // Basic set separated by dashes and spaces
+        this.basicDataSeparatedByWhitespaceAndDashes = Arrays.stream(etunimetLowercase.split("[ \\-]"))
+                .map(String::trim)
+                .collect(toList());
+
     }
 
     public boolean isValid(String kutsumanimi) {
-        String kutsumanimiLowerCase = kutsumanimi.toLowerCase();
-
-        // Basic set
-        List<String> separatedByWhitespace = Arrays.stream(this.etunimet.split(" "))
-                .map(String::trim)
-                .collect(toList());
-
         // e.g. "arpa-tupla noppa kuutio" => "arpa-tupla" "noppa" "kuutio" "arpa-tupla noppa" "noppa kuutio" "arpa-tupla noppa kuutio"
-        Set<String> subsequentPairs = separatedByWhitespace.stream()
-                .flatMap(etunimi -> this.findSequentialTuples(separatedByWhitespace, etunimi))
+        Set<String> subsequentTuples = this.basicDataSeparatedByWhitespace.stream()
+                .flatMap(etunimi -> this.findSequentialTuples(this.basicDataSeparatedByWhitespace, etunimi))
                 .collect(Collectors.toSet());
 
-        // Basic set separated by dashes and spaces
-        List<String> withoutDashes = Arrays.stream(this.etunimet.split("[ \\-]"))
-                .map(String::trim)
-                .collect(toList());
-        // e.g. "arpa-tupla noppa kuutio" "arpa tupla noppa" "noppa kuutio" "arpa tupla noppa kuutio"
-        Set<String> subsequentWithoutDash = withoutDashes.stream()
-                .flatMap(etunimi -> this.findSequentialTuples(withoutDashes, etunimi))
+        // e.g. "arpa-tupla noppa kuutio" => "arpa" "tupla" "noppa" "kuutio" "arpa tupla noppa" "noppa kuutio" "arpa tupla noppa kuutio"
+        Set<String> subsequentTuplesWithoutDash = this.basicDataSeparatedByWhitespaceAndDashes.stream()
+                .flatMap(etunimi -> this.findSequentialTuples(this.basicDataSeparatedByWhitespaceAndDashes, etunimi))
                 .collect(Collectors.toSet());
+
         // Compare all valid cases
-        return Stream.of(subsequentPairs, subsequentWithoutDash)
+        return Stream.of(subsequentTuples, subsequentTuplesWithoutDash)
                 .flatMap(Collection::stream)
                 .map(String::toLowerCase)
                 .distinct()
-                .anyMatch(etunimi -> etunimi.equals(kutsumanimiLowerCase));
+                .anyMatch(etunimi -> etunimi.equals(kutsumanimi.toLowerCase()));
     }
 
-    private Stream<? extends String> findSequentialTuples(List<String> separatedByWhitespace, String etunimi) {
-        int currentIndex = separatedByWhitespace.indexOf(etunimi);
-        int finalIndex = separatedByWhitespace.size();
+    private Stream<? extends String> findSequentialTuples(List<String> basicDataSet, String etunimi) {
+        int currentIndex = basicDataSet.indexOf(etunimi);
+        int finalIndex = basicDataSet.size();
         Set<String> set = new HashSet<>();
         // Go through sequential tuples with all valid tuple sizes
         for (int tupleSize = 1; tupleSize <= finalIndex; tupleSize++) {
             for (int i = currentIndex; i <= finalIndex-tupleSize; i++) {
-                String flatSet = separatedByWhitespace.subList(i, i + tupleSize).stream()
+                String flatSet = basicDataSet.subList(i, i + tupleSize).stream()
                         .reduce((currentEtunimi, nextEtunimi) -> currentEtunimi + " " + nextEtunimi)
                         .orElseThrow(RuntimeException::new);
                 set.add(flatSet);

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
@@ -43,13 +43,13 @@ public final class KutsumanimiValidator {
                 .anyMatch(etunimi -> etunimi.equals(kutsumanimi.toLowerCase()));
     }
 
-    private Stream<? extends String> findSequentialTuples(List<String> basicDataSet, String etunimi) {
+    private Stream<String> findSequentialTuples(List<String> basicDataSet, String etunimi) {
         int currentIndex = basicDataSet.indexOf(etunimi);
         int finalIndex = basicDataSet.size();
         Set<String> set = new HashSet<>();
         // Go through sequential tuples with all valid tuple sizes
         for (int tupleSize = 1; tupleSize <= finalIndex; tupleSize++) {
-            for (int i = currentIndex; i <= finalIndex-tupleSize; i++) {
+            for (int i = currentIndex; i <= finalIndex - tupleSize; i++) {
                 String flatSet = basicDataSet.subList(i, i + tupleSize).stream()
                         .reduce((currentEtunimi, nextEtunimi) -> currentEtunimi + " " + nextEtunimi)
                         .orElseThrow(RuntimeException::new);

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidator.java
@@ -50,8 +50,8 @@ public final class KutsumanimiValidator {
         Set<String> set = new HashSet<>();
         // Go through sequential tuples with all valid tuple sizes
         IntStream.range(1, finalIndex + 1).forEach(tupleSize ->
-                IntStream.range(currentIndex, finalIndex - tupleSize + 1).forEach(i -> {
-                    String flatTuple = basicDataSet.subList(i, i + tupleSize).stream()
+                IntStream.range(currentIndex, finalIndex - tupleSize + 1).forEach(currentTuple -> {
+                    String flatTuple = basicDataSet.subList(currentTuple, currentTuple + tupleSize).stream()
                             .reduce((currentEtunimi, nextEtunimi) -> currentEtunimi + " " + nextEtunimi)
                             .orElseThrow(RuntimeException::new);
                     set.add(flatTuple);

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
@@ -7,19 +7,46 @@ public class KutsumanimiValidatorTest {
 
     @Test
     public void testIsValid() {
-        KutsumanimiValidator validator = new KutsumanimiValidator("Anna-Liisa Milla Karoliina");
+        KutsumanimiValidator validator = new KutsumanimiValidator("Anna-Liisa Milla Karoliina Anitra Kristiina");
 
         assertThat(validator.isValid("Anna")).isTrue();
         assertThat(validator.isValid("Liisa")).isTrue();
         assertThat(validator.isValid("Anna-Liisa")).isTrue();
         assertThat(validator.isValid("Milla")).isTrue();
         assertThat(validator.isValid("Karoliina")).isTrue();
-        assertThat(validator.isValid("Milla Karoliina")).isTrue();
+        assertThat(validator.isValid("Anitra")).isTrue();
+        assertThat(validator.isValid("Kristiina")).isTrue();
 
         assertThat(validator.isValid("Karo")).isFalse();
         assertThat(validator.isValid("liina")).isFalse();
         assertThat(validator.isValid("iisa")).isFalse();
         assertThat(validator.isValid("Sanna")).isFalse();
+    }
+
+    @Test
+    public void testMultipleNames() {
+        KutsumanimiValidator validator = new KutsumanimiValidator("Anna-Liisa Milla Karoliina Anitra Kristiina");
+        assertThat(validator.isValid("Anna-Liisa Milla")).isTrue();
+        assertThat(validator.isValid("Anna-Liisa Milla Karoliina")).isTrue();
+        assertThat(validator.isValid("Anna-Liisa Milla Karoliina Anitra")).isTrue();
+        assertThat(validator.isValid("Anna-Liisa Milla Karoliina Anitra Kristiina")).isTrue();
+        assertThat(validator.isValid("Milla Karoliina Anitra Kristiina")).isTrue();
+        assertThat(validator.isValid("Karoliina Anitra Kristiina")).isTrue();
+        assertThat(validator.isValid("Anitra Kristiina")).isTrue();
+
+        assertThat(validator.isValid("Anna Liisa")).isTrue();
+        assertThat(validator.isValid("Liisa Milla")).isTrue();
+        assertThat(validator.isValid("Anna Liisa Milla Karoliina")).isTrue();
+        assertThat(validator.isValid("Liisa Milla Karoliina")).isTrue();
+        assertThat(validator.isValid("Liisa Milla Karoliina Anitra")).isTrue();
+        assertThat(validator.isValid("Anna Liisa Milla Karoliina Anitra")).isTrue();
+        assertThat(validator.isValid("Liisa Milla Karoliina Anitra Kristiina")).isTrue();
+        assertThat(validator.isValid("Anna Liisa Milla Karoliina Anitra Kristiina")).isTrue();
+
+        assertThat(validator.isValid("Anna Milla")).isFalse();
+        assertThat(validator.isValid("Milla Anitra")).isFalse();
+        assertThat(validator.isValid("Liisa Anna")).isFalse();
+
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 public class KutsumanimiValidatorTest {
 
     @Test
-    public void testIsValid() {
+    public void testBasicCases() {
         KutsumanimiValidator validator = new KutsumanimiValidator("Anna-Liisa Milla Karoliina Anitra Kristiina");
 
         assertThat(validator.isValid("Anna")).isTrue();
@@ -26,27 +26,35 @@ public class KutsumanimiValidatorTest {
     @Test
     public void testMultipleNames() {
         KutsumanimiValidator validator = new KutsumanimiValidator("Anna-Liisa Milla Karoliina Anitra Kristiina");
-        assertThat(validator.isValid("Anna-Liisa Milla")).isTrue();
-        assertThat(validator.isValid("Anna-Liisa Milla Karoliina")).isTrue();
-        assertThat(validator.isValid("Anna-Liisa Milla Karoliina Anitra")).isTrue();
-        assertThat(validator.isValid("Anna-Liisa Milla Karoliina Anitra Kristiina")).isTrue();
-        assertThat(validator.isValid("Milla Karoliina Anitra Kristiina")).isTrue();
-        assertThat(validator.isValid("Karoliina Anitra Kristiina")).isTrue();
-        assertThat(validator.isValid("Anitra Kristiina")).isTrue();
-
+        // Sequential pairs
         assertThat(validator.isValid("Anna Liisa")).isTrue();
         assertThat(validator.isValid("Liisa Milla")).isTrue();
-        assertThat(validator.isValid("Anna Liisa Milla Karoliina")).isTrue();
-        assertThat(validator.isValid("Liisa Milla Karoliina")).isTrue();
-        assertThat(validator.isValid("Liisa Milla Karoliina Anitra")).isTrue();
-        assertThat(validator.isValid("Anna Liisa Milla Karoliina Anitra")).isTrue();
-        assertThat(validator.isValid("Liisa Milla Karoliina Anitra Kristiina")).isTrue();
-        assertThat(validator.isValid("Anna Liisa Milla Karoliina Anitra Kristiina")).isTrue();
+        assertThat(validator.isValid("Anna-Liisa Milla")).isTrue();
+        assertThat(validator.isValid("Milla Karoliina")).isTrue();
+        assertThat(validator.isValid("Karoliina Anitra")).isTrue();
+        assertThat(validator.isValid("Anitra Kristiina")).isTrue();
 
         assertThat(validator.isValid("Anna Milla")).isFalse();
         assertThat(validator.isValid("Milla Anitra")).isFalse();
         assertThat(validator.isValid("Liisa Anna")).isFalse();
 
+        // Sequential triples
+        assertThat(validator.isValid("Anna-Liisa Milla Karoliina")).isTrue();
+        assertThat(validator.isValid("Liisa Milla Karoliina")).isTrue();
+        assertThat(validator.isValid("Karoliina Anitra Kristiina")).isTrue();
+
+        // Sqeuantial quadruples
+        assertThat(validator.isValid("Anna-Liisa Milla Karoliina Anitra")).isTrue();
+        assertThat(validator.isValid("Milla Karoliina Anitra Kristiina")).isTrue();
+        assertThat(validator.isValid("Anna Liisa Milla Karoliina")).isTrue();
+        assertThat(validator.isValid("Liisa Milla Karoliina Anitra")).isTrue();
+
+        // Sqeuanetial quintuple
+        assertThat(validator.isValid("Anna Liisa Milla Karoliina Anitra")).isTrue();
+        assertThat(validator.isValid("Liisa Milla Karoliina Anitra Kristiina")).isTrue();
+
+        // Sequential hextuple
+        assertThat(validator.isValid("Anna Liisa Milla Karoliina Anitra Kristiina")).isTrue();
     }
 
     @Test
@@ -64,5 +72,6 @@ public class KutsumanimiValidatorTest {
         KutsumanimiValidator validator = new KutsumanimiValidator("Jorma teppo");
         assertThat(validator.isValid("jorma")).isTrue();
         assertThat(validator.isValid("Teppo")).isTrue();
+        assertThat(validator.isValid("jorma Teppo")).isTrue();
     }
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
@@ -28,7 +28,6 @@ public class KutsumanimiValidatorTest {
         KutsumanimiValidator validator = new KutsumanimiValidator("AnnaFIA Fia-Maarit");
         assertThat(validator.isValid("Fia")).isTrue();
 
-        //
         validator = new KutsumanimiValidator("Manh Man");
         assertThat(validator.isValid("Man")).isTrue();
     }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
@@ -20,14 +20,23 @@ public class KutsumanimiValidatorTest {
         assertThat(validator.isValid("liina")).isFalse();
         assertThat(validator.isValid("iisa")).isFalse();
         assertThat(validator.isValid("Sanna")).isFalse();
-
-        validator = new KutsumanimiValidator("Manh Man");
-        assertThat(validator.isValid("Man")).isTrue();
-
-        validator = new KutsumanimiValidator("Jorma teppo");
-        assertThat(validator.isValid("jorma")).isTrue();
-        assertThat(validator.isValid("Teppo")).isTrue();
-
     }
 
+    @Test
+    public void testCornerCases() {
+        // First etunimi contains kutsumanimi which is in two part other name
+        KutsumanimiValidator validator = new KutsumanimiValidator("AnnaFIA Fia-Maarit");
+        assertThat(validator.isValid("Fia")).isTrue();
+
+        //
+        validator = new KutsumanimiValidator("Manh Man");
+        assertThat(validator.isValid("Man")).isTrue();
+    }
+
+    @Test
+    public void testCaseInsensitivity() {
+        KutsumanimiValidator validator = new KutsumanimiValidator("Jorma teppo");
+        assertThat(validator.isValid("jorma")).isTrue();
+        assertThat(validator.isValid("Teppo")).isTrue();
+    }
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/KutsumanimiValidatorTest.java
@@ -24,6 +24,20 @@ public class KutsumanimiValidatorTest {
     }
 
     @Test
+    public void testBasicCasesWithMultipleDashes() {
+        KutsumanimiValidator validator = new KutsumanimiValidator("Anna Liisa Milla-Karoliina Anitra-Kristiina");
+
+        assertThat(validator.isValid("Anna")).isTrue();
+        assertThat(validator.isValid("Liisa")).isTrue();
+        assertThat(validator.isValid("Milla-Karoliina")).isTrue();
+        assertThat(validator.isValid("Milla")).isTrue();
+        assertThat(validator.isValid("Karoliina")).isTrue();
+        assertThat(validator.isValid("Anitra-Kristiina")).isTrue();
+        assertThat(validator.isValid("Anitra")).isTrue();
+        assertThat(validator.isValid("Kristiina")).isTrue();
+    }
+
+    @Test
     public void testMultipleNames() {
         KutsumanimiValidator validator = new KutsumanimiValidator("Anna-Liisa Milla Karoliina Anitra Kristiina");
         // Sequential pairs


### PR DESCRIPTION
- Korjaa bugin kutsumanimivalidaattorista, jossa jos ensimmäinen etunimi sisältää kutsumanimen ja kutsumanimi on osa väliviivalla erotettua seuraava toista etunimeä validointi ei hyväksy kutsumanimeä
- Validaattorin uudelleenkirjoitus naiivimmalla menetelmällä, ettei vastaavia vaikeasti havaittavia bugeja pääse esiintymään