### PR TITLE
KJHH-1418_yksilointivirheet

### DIFF
--- a/oppijanumerorekisteri-api/pom.xml
+++ b/oppijanumerorekisteri-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>oppijanumerorekisteri</artifactId>
         <groupId>fi.vm.sade.oppijanumerorekisteri</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloDto.java
@@ -72,6 +72,8 @@ public class HenkiloDto implements Serializable {
 
     private Set<YhteystiedotRyhmaDto> yhteystiedotRyhma = new HashSet<>();
 
+    private Set<YksilointiVirheDto> yksilointivirheet = new HashSet<>();
+
     @Deprecated
     public HenkiloTyyppi getHenkiloTyyppi() {
         return HenkiloTyyppi.OPPIJA;

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloVahvaTunnistusDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloVahvaTunnistusDto.java
@@ -25,9 +25,4 @@ public class HenkiloVahvaTunnistusDto {
         this.hetu = requireNonNull(hetu);
     }
 
-    @Deprecated
-    public HenkiloVahvaTunnistusDto(String hetu, String etunimet, String sukunimi) {
-        this(hetu);
-    }
-
 }

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/YksilointiVirheDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/YksilointiVirheDto.java
@@ -1,0 +1,16 @@
+package fi.vm.sade.oppijanumerorekisteri.dto;
+
+import fi.vm.sade.oppijanumerorekisteri.enums.YksilointivirheTila;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+@Getter
+@Setter
+public class YksilointiVirheDto {
+    private YksilointivirheTila yksilointivirheTila;
+
+    private Date uudelleenyritysAikaleima;
+
+}

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/enums/YksilointivirheTila.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/enums/YksilointivirheTila.java
@@ -2,6 +2,7 @@ package fi.vm.sade.oppijanumerorekisteri.enums;
 
 public enum YksilointivirheTila {
     HETU_EI_VTJ,
+    HETU_EI_OIKEA,
     MUU_UUDELLEENYRITETTAVA,
     MUU,
 }

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/enums/YksilointivirheTila.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/enums/YksilointivirheTila.java
@@ -1,0 +1,7 @@
+package fi.vm.sade.oppijanumerorekisteri.enums;
+
+public enum YksilointivirheTila {
+    HETU_EI_VTJ,
+    MUU_UUDELLEENYRITETTAVA,
+    MUU,
+}

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/DtoUtils.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/DtoUtils.java
@@ -63,7 +63,7 @@ public class DtoUtils {
         return new HenkiloDto(oidHenkilo, hetu, passivoitu, etunimet, kutsumanimi, sukunimi,
                  aidinkieli, aidinkieli, Collections.singleton(aidinkieli), Collections.singleton(kansalaisuus), kasittelija,
                 syntymaAika, "1", null, "1.2.3.4.5", null, false, false, false, false, false, createdModified,
-                createdModified, null, null, Collections.singleton(yhteystiedotRyhmaDto));
+                createdModified, null, null, Collections.singleton(yhteystiedotRyhmaDto), new HashSet<>());
     }
 
     public static HenkiloCreateDto createHenkiloCreateDto(String etunimet, String kutsumanimi, String sukunimi, String hetu, String oidHenkilo,

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/validation/HetuUtils.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/validation/HetuUtils.java
@@ -1,11 +1,8 @@
 package fi.vm.sade.oppijanumerorekisteri.validation;
 
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 
 public class HetuUtils {
     private static final char[] tarkistusmerkit = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','H','J','K','L','M','N','P','R','S','T','U','V','W','X','Y'};

--- a/oppijanumerorekisteri-domain/pom.xml
+++ b/oppijanumerorekisteri-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>oppijanumerorekisteri</artifactId>
         <groupId>fi.vm.sade.oppijanumerorekisteri</groupId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/YksilointivirheDtoMapper.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/YksilointivirheDtoMapper.java
@@ -1,0 +1,37 @@
+package fi.vm.sade.oppijanumerorekisteri.mappers;
+
+import fi.vm.sade.oppijanumerorekisteri.dto.YksilointiVirheDto;
+import fi.vm.sade.oppijanumerorekisteri.enums.YksilointivirheTila;
+import fi.vm.sade.oppijanumerorekisteri.models.Yksilointivirhe;
+import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.metadata.Type;
+import org.springframework.stereotype.Component;
+
+@Component
+public class YksilointivirheDtoMapper extends CustomConverter<Yksilointivirhe, YksilointiVirheDto> {
+
+    @Override
+    public YksilointiVirheDto convert(Yksilointivirhe source,
+                                      Type<? extends YksilointiVirheDto> destinationType,
+                                      MappingContext mappingContext) {
+        YksilointiVirheDto yksilointiVirheDto = new YksilointiVirheDto();
+        this.mapperFacade.map(source, yksilointiVirheDto);
+
+        YksilointivirheTila yksilointivirheTila;
+        if ("fi.vm.sade.oppijanumerorekisteri.exceptions.SuspendableIdentificationException".equals(source.getPoikkeus())) {
+            if (source.getViesti().startsWith("Henkilöä ei löytynyt VTJ-palvelusta henkilötunnuksella: ")) {
+                yksilointivirheTila = YksilointivirheTila.HETU_EI_VTJ;
+            }
+            else {
+                yksilointivirheTila = YksilointivirheTila.MUU;
+            }
+        }
+        else {
+            yksilointivirheTila = YksilointivirheTila.MUU_UUDELLEENYRITETTAVA;
+        }
+        yksilointiVirheDto.setYksilointivirheTila(yksilointivirheTila);
+
+        return yksilointiVirheDto;
+    }
+}

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/YksilointivirheDtoMapper.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/YksilointivirheDtoMapper.java
@@ -23,6 +23,9 @@ public class YksilointivirheDtoMapper extends CustomConverter<Yksilointivirhe, Y
             if (source.getViesti().startsWith("Henkilöä ei löytynyt VTJ-palvelusta henkilötunnuksella: ")) {
                 yksilointivirheTila = YksilointivirheTila.HETU_EI_VTJ;
             }
+            else if (source.getViesti().startsWith("Henkilön hetu ei ole oikea: ")) {
+                yksilointivirheTila = YksilointivirheTila.HETU_EI_OIKEA;
+            }
             else {
                 yksilointivirheTila = YksilointivirheTila.MUU;
             }

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -28,6 +28,7 @@ import org.hibernate.envers.RelationTargetAuditMode;
                         @NamedAttributeNode("asiointiKieli"),
                         @NamedAttributeNode("aidinkieli"),
                         @NamedAttributeNode("kielisyys"),
+                        @NamedAttributeNode("yksilointivirheet"),
                 }
         )
 })
@@ -126,8 +127,11 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
     @Column(name = "kasittelija")
     private String kasittelijaOid;
 
-    // Koodisto uses value "1" for male and "2" for female.
-    private String sukupuoli;
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "henkilo")
+    @NotAudited
+    Set<Yksilointivirhe> yksilointivirheet = new HashSet<>();
+
+    private String sukupuoli; // sukupuoli-koodisto
 
     private LocalDate syntymaaika;
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -219,8 +219,8 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
         this.turvakielto = turvakielto;
     }
 
-    public Boolean hasNoFakeHetu() {
-        return !(hetu.charAt(7) == '9');
+    public Boolean isHetuFake() {
+        return hetu.charAt(7) == '9';
     }
 
     public boolean addOrganisaatio(Organisaatio organisaatio) {

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -127,7 +127,7 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
     @Column(name = "kasittelija")
     private String kasittelijaOid;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "henkilo")
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "henkilo", orphanRemoval = true)
     @NotAudited
     Set<Yksilointivirhe> yksilointivirheet = new HashSet<>();
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -127,7 +127,7 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
     @Column(name = "kasittelija")
     private String kasittelijaOid;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "henkilo", orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "henkilo", orphanRemoval = true, cascade = CascadeType.PERSIST)
     @NotAudited
     Set<Yksilointivirhe> yksilointivirheet = new HashSet<>();
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -95,10 +95,6 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
     @Column(nullable = false)
     private boolean yksilointiYritetty;
 
-    @Column(name = "ei_yksiloida", nullable = false)
-    @Deprecated // kts. Yksilointivirhe-entiteetti
-    private boolean eiYksiloida;
-
     @Column(nullable = false)
     private boolean duplicate;
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Yksilointivirhe.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Yksilointivirhe.java
@@ -1,8 +1,6 @@
 package fi.vm.sade.oppijanumerorekisteri.models;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,6 +20,8 @@ import java.util.Date;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "yksilointivirhe", uniqueConstraints = {
         @UniqueConstraint(name = "uk_yksilointivirhe_01", columnNames = "henkilo_id"),
@@ -41,6 +41,12 @@ public class Yksilointivirhe extends IdentifiableAndVersionedEntity {
 
     @Column(name = "viesti")
     private String viesti;
+
+    @Column(name = "uudelleenyritys_maara")
+    private Integer uudelleenyritysMaara;
+
+    @Column(name = "uudelleenyritys_aikaleima")
+    private Date uudelleenyritysAikaleima;
 
     public Yksilointivirhe(Henkilo henkilo) {
         this.henkilo = henkilo;

--- a/oppijanumerorekisteri-service/pom.xml
+++ b/oppijanumerorekisteri-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>fi.vm.sade.oppijanumerorekisteri</groupId>
         <artifactId>oppijanumerorekisteri</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/exceptions/SuspendableIdentificationException.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/exceptions/SuspendableIdentificationException.java
@@ -2,6 +2,8 @@ package fi.vm.sade.oppijanumerorekisteri.exceptions;
 
 public class SuspendableIdentificationException extends OppijanumerorekisteriException {
 
+    private static final long serialVersionUID = 6829796421533806406L;
+
     public SuspendableIdentificationException() {
     }
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/exceptions/SuspendableIdentificationException.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/exceptions/SuspendableIdentificationException.java
@@ -1,0 +1,16 @@
+package fi.vm.sade.oppijanumerorekisteri.exceptions;
+
+public class SuspendableIdentificationException extends OppijanumerorekisteriException {
+
+    public SuspendableIdentificationException() {
+    }
+
+    public SuspendableIdentificationException(String message) {
+        super(message);
+    }
+
+    public SuspendableIdentificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
@@ -102,6 +102,11 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
         if (!StringUtils.isEmpty(henkiloUpdateDto.getHetu()) && HetuUtils.hetuIsValid(henkiloUpdateDto.getHetu())) {
             henkiloUpdateDto.setSyntymaaika(HetuUtils.dateFromHetu(henkiloUpdateDto.getHetu()));
             henkiloUpdateDto.setSukupuoli(HetuUtils.sukupuoliFromHetu(henkiloUpdateDto.getHetu()));
+            // In case hetu changes henkilo should be considered pristine from identification point of view
+            if (!Objects.equals(henkiloSaved.getHetu(), henkiloUpdateDto.getHetu())) {
+                henkiloSaved.getYksilointivirheet().clear();
+                henkiloSaved.setYksilointiYritetty(false);
+            }
         }
 
         this.henkiloUpdateSetReusableFields(henkiloUpdateDto, henkiloSaved, false);

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceImpl.java
@@ -77,7 +77,6 @@ public class IdentificationServiceImpl implements IdentificationService {
                 .peek(this::logFaults)
                 .filter(this::hasRetriableYksilointivirhe)
                 .filter(this::hasNoDataInconsistency)
-                .filter(Henkilo::hasNoFakeHetu)
                 .forEach(henkilo -> {
                     this.waitBetweenRequests(vtjRequestDelayInMillis);
                     log.debug("Henkilo {} passed initial validation, {} to identify...", henkilo.getOidHenkilo(), henkilo.isYksilointiYritetty() ? "retrying" : "trying");
@@ -140,14 +139,6 @@ public class IdentificationServiceImpl implements IdentificationService {
         }
         if (!hasNoDataInconsistency(henkilo)) {
             log.debug("Henkilo {} has inconsistent data that must be solved by officials.", henkilo.getOidHenkilo());
-        }
-        /*
-         * Fake SSNs (900-series) are skipped since they have no counterpart in VTJ database, e.g. 123456-912X.
-         * NOTE: If test environment VTJ is fixed change this restriction to only apply for production environment since
-         * test environment uses the 900-series SSNs.
-         */
-        if (!henkilo.hasNoFakeHetu()) {
-            log.debug("Henkilo {} is using a fake SSN and cannot be identified.", henkilo.getOidHenkilo());
         }
     }
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceImpl.java
@@ -7,6 +7,7 @@ import fi.vm.sade.oppijanumerorekisteri.exceptions.NotFoundException;
 import fi.vm.sade.oppijanumerorekisteri.mappers.OrikaConfiguration;
 import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.models.Identification;
+import fi.vm.sade.oppijanumerorekisteri.models.Yksilointivirhe;
 import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.YksilointitietoRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.YksilointivirheRepository;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.Optional;
 
 @Service
@@ -73,7 +75,7 @@ public class IdentificationServiceImpl implements IdentificationService {
     public void identifyHenkilos(Collection<Henkilo> unidentified, Long vtjRequestDelayInMillis) {
         unidentified.stream()
                 .peek(this::logFaults)
-                .filter(this::isNotBlackListed)
+                .filter(this::hasRetriableYksilointivirhe)
                 .filter(this::hasNoDataInconsistency)
                 .filter(Henkilo::hasNoFakeHetu)
                 .forEach(henkilo -> {
@@ -83,8 +85,12 @@ public class IdentificationServiceImpl implements IdentificationService {
                 });
     }
 
-    private boolean isNotBlackListed(Henkilo henkilo) {
-        return !henkilo.isEiYksiloida() && !yksilointivirheRepository.findByHenkilo(henkilo).isPresent();
+    private boolean hasRetriableYksilointivirhe(Henkilo henkilo) {
+        Optional<Yksilointivirhe> yksilointivirhe = yksilointivirheRepository.findByHenkilo(henkilo);
+        boolean yksilointiAikaleimaVoimasssa = yksilointivirhe.isPresent()
+                && yksilointivirhe.get().getUudelleenyritysAikaleima() != null
+                && new Date().after(yksilointivirhe.get().getUudelleenyritysAikaleima());
+        return !yksilointivirhe.isPresent() || yksilointiAikaleimaVoimasssa;
     }
 
     /**
@@ -92,7 +98,7 @@ public class IdentificationServiceImpl implements IdentificationService {
      * Those cases must be solved by officials.
      */
     private boolean hasNoDataInconsistency(Henkilo henkilo) {
-        return !(!henkilo.isYksiloityVTJ() && !henkilo.getHetu().isEmpty() && yksilointitietoRepository.findByHenkilo(henkilo).isPresent());
+        return !(!henkilo.isYksiloityVTJ() && StringUtils.hasLength(henkilo.getHetu()) && yksilointitietoRepository.findByHenkilo(henkilo).isPresent());
     }
 
     @Override
@@ -129,7 +135,7 @@ public class IdentificationServiceImpl implements IdentificationService {
         if (!log.isDebugEnabled()) {
             return;
         }
-        if (!isNotBlackListed(henkilo)) {
+        if (!hasRetriableYksilointivirhe(henkilo)) {
             log.debug("Henkilo {} has been black listed from processing.", henkilo.getOidHenkilo());
         }
         if (!hasNoDataInconsistency(henkilo)) {

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
@@ -14,6 +14,7 @@ import fi.vm.sade.oppijanumerorekisteri.dto.YksilointitietoDto;
 import fi.vm.sade.oppijanumerorekisteri.dto.YksilointiVertailuDto;
 import fi.vm.sade.oppijanumerorekisteri.exceptions.DataInconsistencyException;
 import fi.vm.sade.oppijanumerorekisteri.exceptions.NotFoundException;
+import fi.vm.sade.oppijanumerorekisteri.exceptions.SuspendableIdentificationException;
 import fi.vm.sade.oppijanumerorekisteri.exceptions.ValidationException;
 import fi.vm.sade.oppijanumerorekisteri.mappers.OrikaConfiguration;
 import fi.vm.sade.oppijanumerorekisteri.models.*;
@@ -39,8 +40,11 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -101,7 +105,6 @@ public class YksilointiServiceImpl implements YksilointiService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void tallennaYksilointivirhe(String henkiloOid, Exception exception) {
         henkiloRepository.findByOidHenkilo(henkiloOid).ifPresent(henkilo -> tallennaYksilointivirhe(henkilo, exception));
-
     }
 
     private void tallennaYksilointivirhe(Henkilo henkilo, Exception exception) {
@@ -112,7 +115,27 @@ public class YksilointiServiceImpl implements YksilointiService {
         yksilointivirhe.setAikaleima(new Date());
         yksilointivirhe.setPoikkeus(exception.getClass().getCanonicalName());
         yksilointivirhe.setViesti(exception.getMessage());
+        if (!(exception instanceof SuspendableIdentificationException)) {
+            Integer uusiYritysmaara = Optional.ofNullable(yksilointivirhe.getUudelleenyritysMaara())
+                    .map(maara -> maara++)
+                    .orElse(0);
+            yksilointivirhe.setUudelleenyritysMaara(uusiYritysmaara);
+            yksilointivirhe.setUudelleenyritysAikaleima(this.getUudelleenyritysAikaleima(uusiYritysmaara));
+        }
         yksilointivirheRepository.save(yksilointivirhe);
+    }
+
+    private Date getUudelleenyritysAikaleima(Integer uusiYritysmaara) {
+        LocalDateTime uusiAikaleima;
+        // Limit the exponential result to ~month (41 days)
+        if (uusiYritysmaara > 9 ) {
+            uusiAikaleima = LocalDateTime.now().plusMonths(1L);
+        }
+        else {
+            Function<Integer, Integer> exponentialFunction = maara -> (int)Math.pow(maara, 5) + 10;
+            uusiAikaleima = LocalDateTime.now().plusMinutes(exponentialFunction.apply(uusiYritysmaara));
+        }
+        return Date.from(uusiAikaleima.atZone(ZoneId.systemDefault()).toInstant());
     }
 
     @Override
@@ -147,7 +170,7 @@ public class YksilointiServiceImpl implements YksilointiService {
          */
         YksiloityHenkilo yksiloityHenkilo = vtjClient.fetchHenkilo(henkilo.getHetu())
                 .orElseThrow(() ->
-                        new DataInconsistencyException("Henkilöä ei löytynyt VTJ-palvelusta henkilötunnuksella: " + henkilo.getHetu()));
+                        new SuspendableIdentificationException("Henkilöä ei löytynyt VTJ-palvelusta henkilötunnuksella: " + henkilo.getHetu()));
 
         henkilo.setYksilointiYritetty(true);
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
@@ -164,6 +164,10 @@ public class YksilointiServiceImpl implements YksilointiService {
             throw new ValidationException(String.format("Henkilöä '%s' ei voida yksilöidä koska hetu puuttuu", henkilo.getOidHenkilo()));
         }
 
+        if (henkilo.isHetuFake()) {
+            throw new SuspendableIdentificationException("Henkilön hetu ei ole oikea: " + henkilo.getHetu());
+        }
+
         /* VTJ data for Henkilo contains a huge data set and parsing this data
          * might change in the future, if Henkilo's data must contain all what
          * VTJ has to offer but that's still uncertain

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
@@ -115,6 +115,9 @@ public class YksilointiServiceImpl implements YksilointiService {
         yksilointivirhe.setAikaleima(new Date());
         yksilointivirhe.setPoikkeus(exception.getClass().getCanonicalName());
         yksilointivirhe.setViesti(exception.getMessage());
+        // In case there is prior error already.
+        yksilointivirhe.setUudelleenyritysAikaleima(null);
+        yksilointivirhe.setUudelleenyritysMaara(null);
         if (!(exception instanceof SuspendableIdentificationException)) {
             Integer uusiYritysmaara = Optional.ofNullable(yksilointivirhe.getUudelleenyritysMaara())
                     .map(maara -> maara++)

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloUpdatePostValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloUpdatePostValidator.java
@@ -7,42 +7,32 @@ import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
 import fi.vm.sade.oppijanumerorekisteri.services.Koodisto;
 import fi.vm.sade.oppijanumerorekisteri.services.KoodistoService;
-import fi.vm.sade.oppijanumerorekisteri.services.UserDetailsHelper;
-import java.util.Objects;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+import java.util.Objects;
 import java.util.Set;
+
 import static java.util.stream.Collectors.toSet;
 
 @Component
+@RequiredArgsConstructor
 public class HenkiloUpdatePostValidator implements Validator {
-    private UserDetailsHelper userDetailsHelper;
+    private final KoodistoService koodistoService;
 
-    private KoodistoService koodistoService;
-
-    private HenkiloRepository henkiloRepository;
-
-
-    @Autowired
-    public HenkiloUpdatePostValidator(UserDetailsHelper userDetailsHelper,
-                                      KoodistoService koodistoService,
-                                      HenkiloRepository henkiloRepository) {
-        this.userDetailsHelper = userDetailsHelper;
-        this.koodistoService = koodistoService;
-        this.henkiloRepository = henkiloRepository;
-    }
+    private final HenkiloRepository henkiloRepository;
 
     @Override
-    public boolean supports(Class<?> aClass) {
+    public boolean supports(@NotNull Class<?> aClass) {
         return HenkiloUpdateDto.class.equals(aClass);
     }
 
     @Override
-    public void validate(Object o, Errors errors) {
+    public void validate(Object o, @NotNull Errors errors) {
         HenkiloUpdateDto henkiloUpdateDto = (HenkiloUpdateDto) o;
 
         this.henkiloRepository.findByOidHenkilo(henkiloUpdateDto.getOidHenkilo())

--- a/oppijanumerorekisteri-service/src/main/resources/db/migration/V20180713150856534__yksilointivirhe_uudelleenyritys.sql
+++ b/oppijanumerorekisteri-service/src/main/resources/db/migration/V20180713150856534__yksilointivirhe_uudelleenyritys.sql
@@ -1,0 +1,6 @@
+alter table yksilointivirhe
+    add column uudelleenyritys_maara type integer,
+    add column uudelleenyritys_aikaleima type timestamp without time zone;
+
+alter table henkilo
+    drop column if exists ei_yksiloida;

--- a/oppijanumerorekisteri-service/src/main/resources/db/migration/V20180713150856534__yksilointivirhe_uudelleenyritys.sql
+++ b/oppijanumerorekisteri-service/src/main/resources/db/migration/V20180713150856534__yksilointivirhe_uudelleenyritys.sql
@@ -1,6 +1,6 @@
 alter table yksilointivirhe
-    add column uudelleenyritys_maara type integer,
-    add column uudelleenyritys_aikaleima type timestamp without time zone;
+    add column uudelleenyritys_maara integer,
+    add column uudelleenyritys_aikaleima timestamp without time zone;
 
 alter table henkilo
     drop column if exists ei_yksiloida;

--- a/oppijanumerorekisteri-service/src/main/resources/db/migration/V20180713150856534__yksilointivirhe_uudelleenyritys.sql
+++ b/oppijanumerorekisteri-service/src/main/resources/db/migration/V20180713150856534__yksilointivirhe_uudelleenyritys.sql
@@ -4,3 +4,5 @@ alter table yksilointivirhe
 
 alter table henkilo
     drop column if exists ei_yksiloida;
+
+delete from yksilointivirhe where poikkeus != 'fi.vm.sade.oppijanumerorekisteri.exceptions.SuspendableIdentificationException';

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
@@ -19,11 +19,13 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.groups.Tuple.tuple;
 
 @RunWith(SpringRunner.class)
 @IntegrationTest
@@ -44,6 +46,9 @@ public class HenkiloModificationServiceIntegrationTest {
 
     @Autowired
     private HenkiloViiteRepository henkiloViiteRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Test
     @WithMockUser(roles = "APP_HENKILONHALLINTA_OPHREKISTERI")
@@ -82,6 +87,24 @@ public class HenkiloModificationServiceIntegrationTest {
 
         assertThat(readDto.getEtunimet()).isEqualTo("Teppo Taneli");
         assertThat(readDto.getKutsumanimi()).isEqualTo("Taneli");
+    }
+
+    @Test
+    @WithMockUser(roles = "APP_HENKILONHALLINTA_OPHREKISTERI")
+    public void yksilointivirheRemovedOnHetuChange() {
+        HenkiloUpdateDto updateDto = new HenkiloUpdateDto();
+        updateDto.setOidHenkilo("YKSILOINNISSAVIRHE");
+        updateDto.setHetu("170775-941A");
+
+        henkiloModificationService.updateHenkilo(updateDto);
+        Henkilo henkilo = this.entityManager
+                .createQuery("SELECT h FROM Henkilo h WHERE h.oidHenkilo='YKSILOINNISSAVIRHE'", Henkilo.class)
+                .getSingleResult();
+
+        assertThat(henkilo)
+                .extracting(Henkilo::getOidHenkilo, Henkilo::getHetu, Henkilo::isYksilointiYritetty)
+                .containsExactly("YKSILOINNISSAVIRHE", "170775-941A", false);
+        assertThat(henkilo.getYksilointivirheet()).isEmpty();
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.groups.Tuple.tuple;
 
 @RunWith(SpringRunner.class)
 @IntegrationTest

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiTests.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiTests.java
@@ -216,7 +216,7 @@ public class YksilointiTests {
         henkiloCreateDto.setKutsumanimi("teppo");
         henkiloCreateDto.setEtunimet("teppo");
         henkiloCreateDto.setSukunimi("testaaja");
-        henkiloCreateDto.setHetu("hetu1");
+        henkiloCreateDto.setHetu("190259-817N");
         String yksiloitavaOid = this.henkiloModificationService.createHenkilo(henkiloCreateDto).getOidHenkilo();
 
         YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
@@ -224,7 +224,7 @@ public class YksilointiTests {
         yksiloityHenkilo.setKutsumanimi("teppo");
         yksiloityHenkilo.setSukunimi("testaaja");
         yksiloityHenkilo.setHetu("170498-993H");
-        when(this.vtjClientMock.fetchHenkilo(eq("hetu1"))).thenReturn(Optional.of(yksiloityHenkilo));
+        when(this.vtjClientMock.fetchHenkilo(eq("190259-817N"))).thenReturn(Optional.of(yksiloityHenkilo));
 
         this.yksilointiService.yksiloiAutomaattisesti(yksiloitavaOid);
 
@@ -241,7 +241,7 @@ public class YksilointiTests {
         henkiloCreateDto.setKutsumanimi("teppo");
         henkiloCreateDto.setEtunimet("teppo");
         henkiloCreateDto.setSukunimi("testaaja");
-        henkiloCreateDto.setHetu("hetu1");
+        henkiloCreateDto.setHetu("190259-855W");
         henkiloCreateDto.setYksiloityVTJ(false);
         String yksiloitavaOid = this.henkiloModificationService.createHenkilo(henkiloCreateDto).getOidHenkilo();
 
@@ -258,7 +258,7 @@ public class YksilointiTests {
         yksiloityHenkilo.setKutsumanimi("teppo");
         yksiloityHenkilo.setSukunimi("testaaja");
         yksiloityHenkilo.setHetu("170498-993H");
-        when(this.vtjClientMock.fetchHenkilo(eq("hetu1"))).thenReturn(Optional.of(yksiloityHenkilo));
+        when(this.vtjClientMock.fetchHenkilo(eq("190259-855W"))).thenReturn(Optional.of(yksiloityHenkilo));
 
         this.yksilointiService.yksiloiAutomaattisesti(yksiloitavaOid);
 
@@ -282,7 +282,7 @@ public class YksilointiTests {
         henkiloCreateDto.setKutsumanimi("teppo");
         henkiloCreateDto.setEtunimet("teppo");
         henkiloCreateDto.setSukunimi("testaaja");
-        henkiloCreateDto.setHetu("hetu1");
+        henkiloCreateDto.setHetu("190259-817N");
         henkiloCreateDto.setYksiloityVTJ(false);
         String yksiloitavaOid = this.henkiloModificationService.createHenkilo(henkiloCreateDto).getOidHenkilo();
 
@@ -299,7 +299,7 @@ public class YksilointiTests {
         yksiloityHenkilo.setKutsumanimi("teppo");
         yksiloityHenkilo.setSukunimi("testaaja");
         yksiloityHenkilo.setHetu("170498-993H");
-        when(this.vtjClientMock.fetchHenkilo(eq("hetu1"))).thenReturn(Optional.of(yksiloityHenkilo));
+        when(this.vtjClientMock.fetchHenkilo(eq("190259-817N"))).thenReturn(Optional.of(yksiloityHenkilo));
 
         SecurityContextHolder.getContext().setAuthentication(null);
 

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceImplTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceImplTest.java
@@ -1,0 +1,80 @@
+package fi.vm.sade.oppijanumerorekisteri.services.impl;
+
+import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
+import fi.vm.sade.oppijanumerorekisteri.models.Yksilointivirhe;
+import fi.vm.sade.oppijanumerorekisteri.repositories.YksilointitietoRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.YksilointivirheRepository;
+import fi.vm.sade.oppijanumerorekisteri.services.YksilointiService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@RunWith(SpringRunner.class)
+public class IdentificationServiceImplTest {
+    @InjectMocks
+    private IdentificationServiceImpl identificationService;
+
+    @Mock
+    private YksilointitietoRepository yksilointitietoRepository;
+
+    @Mock
+    private YksilointivirheRepository yksilointivirheRepository;
+
+    @Mock
+    private YksilointiService yksilointiService;
+
+    @Test
+    public void retriableYksilointivirheIsRespected() {
+        Henkilo henkilo = Henkilo.builder()
+                .oidHenkilo("1.2.3.4.5")
+                .hetu("nonfakehetu")
+                .build();
+        LocalDateTime localDateTime = LocalDateTime.now().minusDays(1);
+        Yksilointivirhe yksilointivirhe = Yksilointivirhe.builder()
+                .uudelleenyritysMaara(0)
+                .uudelleenyritysAikaleima(Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant()))
+                .build();
+
+        given(this.yksilointivirheRepository.findByHenkilo(henkilo)).willReturn(Optional.of(yksilointivirhe));
+        this.identificationService.identifyHenkilos(Collections.singleton(henkilo), 1L);
+
+        verify(this.yksilointiService, times(1)).yksiloiAutomaattisesti(eq("1.2.3.4.5"));
+    }
+
+    @Test
+    public void noYksilointivirheIsRespected() {
+        Henkilo henkilo = Henkilo.builder()
+                .oidHenkilo("1.2.3.4.5")
+                .hetu("nonfakehetu")
+                .build();
+        given(this.yksilointivirheRepository.findByHenkilo(henkilo)).willReturn(Optional.empty());
+        this.identificationService.identifyHenkilos(Collections.singleton(henkilo), 1L);
+
+        verify(this.yksilointiService, times(1)).yksiloiAutomaattisesti(eq("1.2.3.4.5"));
+    }
+
+    @Test
+    public void fakeHetuIsNotIdentified() {
+        Henkilo henkilo = Henkilo.builder()
+                .oidHenkilo("1.2.3.4.5")
+                .hetu("fakehet9")
+                .build();
+        given(this.yksilointivirheRepository.findByHenkilo(henkilo)).willReturn(Optional.empty());
+        this.identificationService.identifyHenkilos(Collections.singleton(henkilo), 1L);
+        verifyZeroInteractions(this.yksilointiService);
+    }
+}

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTest.java
@@ -117,7 +117,9 @@ public class IdentificationServiceIntegrationTest {
                 .createQuery("SELECT y FROM Yksilointivirhe y", Yksilointivirhe.class).getResultList();
         assertThat(this.mapper.mapAsList(yksilointivirhe, YksilointiVirheDto.class))
                 .extracting(YksilointiVirheDto::getUudelleenyritysAikaleima, YksilointiVirheDto::getYksilointivirheTila)
-                .containsExactlyInAnyOrder(Tuple.tuple(null, YksilointivirheTila.HETU_EI_VTJ),
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple(null, YksilointivirheTila.HETU_EI_OIKEA),
+                        Tuple.tuple(null, YksilointivirheTila.HETU_EI_VTJ),
                         Tuple.tuple(null, YksilointivirheTila.HETU_EI_VTJ));
 
     }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTest.java
@@ -6,10 +6,15 @@ import fi.vm.sade.oppijanumerorekisteri.KoodiTypeListBuilder;
 import fi.vm.sade.oppijanumerorekisteri.clients.KayttooikeusClient;
 import fi.vm.sade.oppijanumerorekisteri.clients.KoodistoClient;
 import fi.vm.sade.oppijanumerorekisteri.clients.VtjClient;
+import fi.vm.sade.oppijanumerorekisteri.dto.YksilointiVirheDto;
+import fi.vm.sade.oppijanumerorekisteri.enums.YksilointivirheTila;
 import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
+import fi.vm.sade.oppijanumerorekisteri.models.Yksilointivirhe;
 import fi.vm.sade.oppijanumerorekisteri.services.IdentificationService;
 import fi.vm.sade.oppijanumerorekisteri.services.Koodisto;
 import fi.vm.sade.oppijanumerorekisteri.services.MockVtjClient;
+import org.assertj.core.groups.Tuple;
+import org.jresearch.orika.spring.OrikaSpringMapper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,6 +61,9 @@ public class IdentificationServiceIntegrationTest {
     @PersistenceContext
     private EntityManager entityManager;
 
+    @Autowired
+    private OrikaSpringMapper mapper;
+
     @Before
     public void setup() {
         this.mockVtjClient = new MockVtjClient();
@@ -91,5 +99,12 @@ public class IdentificationServiceIntegrationTest {
 
         assertThat(notFoundVtjResult.isYksiloityVTJ()).isFalse();
         assertThat(notFoundVtjResult.isYksilointiYritetty()).isTrue();
+
+        List<Yksilointivirhe> yksilointivirhe = this.entityManager
+                .createQuery("SELECT y FROM Yksilointivirhe y", Yksilointivirhe.class).getResultList();
+        assertThat(this.mapper.mapAsList(yksilointivirhe, YksilointiVirheDto.class))
+                .extracting(YksilointiVirheDto::getUudelleenyritysAikaleima, YksilointiVirheDto::getYksilointivirheTila)
+                .containsExactlyInAnyOrder(Tuple.tuple(null, YksilointivirheTila.HETU_EI_VTJ),
+                        Tuple.tuple(null, YksilointivirheTila.HETU_EI_VTJ));
     }
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTest.java
@@ -100,11 +100,25 @@ public class IdentificationServiceIntegrationTest {
         assertThat(notFoundVtjResult.isYksiloityVTJ()).isFalse();
         assertThat(notFoundVtjResult.isYksilointiYritetty()).isTrue();
 
+    }
+
+    @Test
+    public void yksilointivirhe() {
+        List<Henkilo> unidentifiedHenkilos = this.entityManager
+                .createQuery("SELECT h FROM Henkilo h", Henkilo.class).getResultList();
+
+        given(this.vtjClient.fetchHenkilo("111111-1235")).willReturn(Optional.empty());
+        given(this.vtjClient.fetchHenkilo("010101-123N"))
+                .willReturn(this.mockVtjClient.fetchHenkilo(""));
+
+        this.identificationService.identifyHenkilos(unidentifiedHenkilos, 0L);
+
         List<Yksilointivirhe> yksilointivirhe = this.entityManager
                 .createQuery("SELECT y FROM Yksilointivirhe y", Yksilointivirhe.class).getResultList();
         assertThat(this.mapper.mapAsList(yksilointivirhe, YksilointiVirheDto.class))
                 .extracting(YksilointiVirheDto::getUudelleenyritysAikaleima, YksilointiVirheDto::getYksilointivirheTila)
                 .containsExactlyInAnyOrder(Tuple.tuple(null, YksilointivirheTila.HETU_EI_VTJ),
                         Tuple.tuple(null, YksilointivirheTila.HETU_EI_VTJ));
+
     }
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTests.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/IdentificationServiceIntegrationTests.java
@@ -57,7 +57,7 @@ public class IdentificationServiceIntegrationTests {
     @Test
     public void setStrongIdentifiedHetuNoHetuNamesMatch() {
         HenkiloVahvaTunnistusDto henkiloVahvaTunnistusDto =
-                new HenkiloVahvaTunnistusDto("new hetu", "Teppo Taneli", "Testaaja");
+                new HenkiloVahvaTunnistusDto("new hetu");
 
         this.identificationService.setStrongIdentifiedHetu("NoHetu", henkiloVahvaTunnistusDto);
 
@@ -70,7 +70,7 @@ public class IdentificationServiceIntegrationTests {
     @Test
     public void setStrongIdentifiedHetuCombineWithOppija() {
         HenkiloVahvaTunnistusDto henkiloVahvaTunnistusDto =
-                new HenkiloVahvaTunnistusDto("010101-234R", "Teppo Taneli", "Testaaja");
+                new HenkiloVahvaTunnistusDto("010101-234R");
 
         this.identificationService.setStrongIdentifiedHetu("NoHetu", henkiloVahvaTunnistusDto);
 
@@ -88,7 +88,7 @@ public class IdentificationServiceIntegrationTests {
     @Test
     public void setStrongIdentifiedHetuHetuAndNimetMatch() {
         HenkiloVahvaTunnistusDto henkiloVahvaTunnistusDto =
-                new HenkiloVahvaTunnistusDto("010101-123N", "Teppo Taneli", "Testaaja");
+                new HenkiloVahvaTunnistusDto("010101-123N");
 
         this.identificationService.setStrongIdentifiedHetu("EverythingOK", henkiloVahvaTunnistusDto);
 
@@ -101,7 +101,7 @@ public class IdentificationServiceIntegrationTests {
     @Test(expected = RuntimeException.class)
     public void setStrongIdentifiedHetu() {
         HenkiloVahvaTunnistusDto henkiloVahvaTunnistusDto =
-                new HenkiloVahvaTunnistusDto("111111-1235", "Teppo", "Testaaja");
+                new HenkiloVahvaTunnistusDto("111111-1235");
 
         this.identificationService.setStrongIdentifiedHetu("EverythingOK", henkiloVahvaTunnistusDto);
     }
@@ -151,5 +151,4 @@ public class IdentificationServiceIntegrationTests {
                         tuple("yhteystietotyyppi2", singletonList("etu.suku@example.com"), "alkupera2")
                 );
     }
-
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloUpdatePostValidatorTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloUpdatePostValidatorTest.java
@@ -26,8 +26,6 @@ public class HenkiloUpdatePostValidatorTest {
     private HenkiloUpdatePostValidator validator;
 
     @Mock
-    private UserDetailsHelper userDetailsHelper;
-    @Mock
     private KoodistoService koodistoService;
     @Mock
     private HenkiloRepository henkiloRepository;
@@ -36,8 +34,7 @@ public class HenkiloUpdatePostValidatorTest {
 
     @Before
     public void setup() {
-        validator = new HenkiloUpdatePostValidator(userDetailsHelper,
-                koodistoService, henkiloRepository);
+        validator = new HenkiloUpdatePostValidator(koodistoService, henkiloRepository);
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
+++ b/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
@@ -1,4 +1,4 @@
-INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate, eisuomalaistahetua, ei_yksiloida, passivoitu, yksilointi_yritetty, yksiloity, yksiloityvtj, etunimet, kutsumanimi, sukunimi) VALUES
-(-1, 0, '111111-985K', 'VTJYKSILOITY1', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-2, 0, '111111-1234', 'VTJYKSILOITY2', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja')
+INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate, eisuomalaistahetua, passivoitu, yksilointi_yritetty, yksiloity, yksiloityvtj, etunimet, kutsumanimi, sukunimi) VALUES
+(-1, 0, '111111-985K', 'VTJYKSILOITY1', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-2, 0, '111111-1234', 'VTJYKSILOITY2', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja')
 ;

--- a/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
+++ b/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
@@ -1,4 +1,9 @@
 INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate, eisuomalaistahetua, passivoitu, yksilointi_yritetty, yksiloity, yksiloityvtj, etunimet, kutsumanimi, sukunimi) VALUES
 (-1, 0, '111111-985K', 'VTJYKSILOITY1', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-2, 0, '111111-1234', 'VTJYKSILOITY2', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja')
+(-2, 0, '111111-1234', 'VTJYKSILOITY2', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-3, 0, '170798-9330', 'YKSILOINNISSAVIRHE', NOW(), NOW(), FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja')
+;
+
+INSERT INTO yksilointivirhe (id, version, aikaleima, poikkeus, henkilo_id) VALUES
+(-1, 0, NOW(), 'fi.vm.sade.oppijanumerorekisteri.exceptions.SuspendableIdentificationException', -3)
 ;

--- a/oppijanumerorekisteri-service/src/test/resources/sql/yksilointi-test.sql
+++ b/oppijanumerorekisteri-service/src/test/resources/sql/yksilointi-test.sql
@@ -1,5 +1,5 @@
-INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate, eisuomalaistahetua, ei_yksiloida, passivoitu, yksilointi_yritetty, yksiloity, yksiloityvtj, etunimet, kutsumanimi, sukunimi) VALUES
-(1, 0, '111111-985K', 'FakeSSN', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(2, 0, '111111-1234', 'Blacklisted', NOW(), NOW(), FALSE, FALSE, TRUE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(3, 0, '111111-1235', 'NotInVTJ', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(4, 0, '010101-123N', 'EverythingOK', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja');
+INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate, eisuomalaistahetua, passivoitu, yksilointi_yritetty, yksiloity, yksiloityvtj, etunimet, kutsumanimi, sukunimi) VALUES
+(1, 0, '111111-985K', 'FakeSSN', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(2, 0, '111111-1234', 'Blacklisted', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(3, 0, '111111-1235', 'NotInVTJ', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(4, 0, '010101-123N', 'EverythingOK', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja');

--- a/oppijanumerorekisteri-service/src/test/resources/sql/yksilointi-test2.sql
+++ b/oppijanumerorekisteri-service/src/test/resources/sql/yksilointi-test2.sql
@@ -1,11 +1,11 @@
-INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate, eisuomalaistahetua, ei_yksiloida, passivoitu, yksilointi_yritetty, yksiloity, yksiloityvtj, etunimet, kutsumanimi, sukunimi) VALUES
-(-1, 0, '111111-1235', 'SomeOtherVirkailija', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-2, 0, '010101-123N', 'EverythingOK', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-3, 0, '010101-123M', 'Tyoosoite', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-4, 0, '010101-123L', 'TyoosoiteVainLuku', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-5, 0, '010101-123K', 'Kotiosoite', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-6, 0, '010101-234R', 'EverythingOkOppija', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-7, 0, NULL, 'NoHetu', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja');
+INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate, eisuomalaistahetua, passivoitu, yksilointi_yritetty, yksiloity, yksiloityvtj, etunimet, kutsumanimi, sukunimi) VALUES
+(-1, 0, '111111-1235', 'SomeOtherVirkailija', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-2, 0, '010101-123N', 'EverythingOK', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-3, 0, '010101-123M', 'Tyoosoite', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-4, 0, '010101-123L', 'TyoosoiteVainLuku', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-5, 0, '010101-123K', 'Kotiosoite', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-6, 0, '010101-234R', 'EverythingOkOppija', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-7, 0, NULL, 'NoHetu', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja');
 
 INSERT INTO yhteystiedotryhma (id, version, henkilo_id, ryhmakuvaus, read_only, ryhma_alkuperatieto) VALUES
 (-1, 0, (SELECT id FROM henkilo where oidhenkilo = 'Tyoosoite'), 'yhteystietotyyppi2', FALSE, 'alkupera6');

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.vm.sade.oppijanumerorekisteri</groupId>
     <artifactId>oppijanumerorekisteri</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <organization>


### PR DESCRIPTION
Yksilöintivirheet jaettu uudelleen yritettäviin ja ei uudelleen yritettäviin
- Jos hetua ei löydy VRK:sta ei yritetä uudelleen
- Jos henkilöllä on 9-hetu ei yritetä uudelleen
- Muuten yritetään uudelleen seuraavan kaavan mukaan x^5+10 tai maksimissaan ~41 vuorokautta.

Hetun muuttaminen nollaa yksilöintivirheet jolloin yritetään yksilöintiä taas automaattisesti.

Uudelleenyksilöidään kaikki vanhat virheelliset.
