### PR TITLE
KJHH-1463: Korjaa duplikaattihenkilöt tuonnin listauksesta

### DIFF
--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/YksilointiTila.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/YksilointiTila.java
@@ -3,7 +3,7 @@ package fi.vm.sade.oppijanumerorekisteri.dto;
 public enum YksilointiTila {
 
     /**
-     * Henkilö on yksilöity (joko manuaaalisesti tai automaattisesti).
+     * Henkilö on yksilöity (joko manuaaalisesti tai automaattisesti) tai passivoitu.
      */
     OK,
     /**

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -244,6 +244,9 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
      * @see YksilointiTila tilojen määritykset
      */
     public YksilointiTila getYksilointiTila() {
+        if (duplicate || passivoitu) {
+            return YksilointiTila.OK;
+        }
         if (yksiloity || yksiloityVTJ) {
             return YksilointiTila.OK;
         }

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloJpaRepository.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloJpaRepository.java
@@ -134,8 +134,9 @@ public interface HenkiloJpaRepository {
     /**
      * Palauttaa yksilöityjen henkilöiden lukumäärän. Yksilöidyksi lasketaan
      * sekä manuaalisesti yksilöidyt hetuttomat että automaattisesti yksilöidyt
-     * hetulliset henkilöt.
+     * hetulliset henkilöt ja passivoidut.
      *
+     * @see YksilointiTila#OK
      * @param criteria hakukriteerit
      * @return onnistuneiden lukumäärä
      */
@@ -147,6 +148,8 @@ public interface HenkiloJpaRepository {
      * hetulliset henkilöt joille {@link Henkilo#yksilointiYritetty} on
      * <code>true</code>.
      *
+     * @see YksilointiTila#HETU_PUUTTUU
+     * @see YksilointiTila#VIRHE
      * @param criteria hakukriteerit
      * @return virheellisten lukumäärä
      */
@@ -157,6 +160,7 @@ public interface HenkiloJpaRepository {
      * Keskeneräisiä ovat hetulliset henkilöt joita ei ole vielä yksilöity ja
      * {@link Henkilo#yksilointiYritetty} on <code>false</code>.
      *
+     * @see YksilointiTila#KESKEN
      * @param criteria hakukriteerit
      * @return keskeneräisten lukumäärä
      */

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
@@ -534,6 +534,8 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
         QHenkilo qHenkilo = QHenkilo.henkilo;
         return criteria.getQuery(entityManager, qHenkilo)
                 .where(anyOf(
+                        qHenkilo.duplicate.isTrue(),
+                        qHenkilo.passivoitu.isTrue(),
                         qHenkilo.yksiloity.isTrue(),
                         qHenkilo.yksiloityVTJ.isTrue()
                 )).select(qHenkilo.oidHenkilo).distinct().fetchCount();
@@ -543,6 +545,7 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
     public long countByYksilointiVirheet(OppijaTuontiCriteria criteria) {
         QHenkilo qHenkilo = QHenkilo.henkilo;
         return criteria.getQuery(entityManager, qHenkilo)
+                .where(qHenkilo.duplicate.isFalse(),  qHenkilo.passivoitu.isFalse())
                 .where(anyOf(
                         allOf(
                                 qHenkilo.hetu.isNull(),
@@ -563,6 +566,8 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
         QHenkilo qHenkilo = QHenkilo.henkilo;
         return criteria.getQuery(entityManager, qHenkilo)
                 .where(allOf(
+                        qHenkilo.duplicate.isFalse(),
+                        qHenkilo.passivoitu.isFalse(),
                         qHenkilo.hetu.isNotNull(),
                         qHenkilo.yksiloity.isFalse(),
                         qHenkilo.yksiloityVTJ.isFalse(),


### PR DESCRIPTION
Duplikaattihenkilöt näkyivät virheellisesti virheinä virkailijalle.