### PR TITLE
Lisää yksilöityjen hetujen historian

### DIFF
--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloDto.java
@@ -24,6 +24,8 @@ public class HenkiloDto implements Serializable {
 
     private String hetu;
 
+    private Set<String> yksiloityHetu;
+
     private boolean passivoitu;
 
     private String etunimet;

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloDto.java
@@ -24,7 +24,7 @@ public class HenkiloDto implements Serializable {
 
     private String hetu;
 
-    private Set<String> yksiloityHetu;
+    private Set<String> kaikkiHetut;
 
     private boolean passivoitu;
 

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceUpdateDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceUpdateDto.java
@@ -11,7 +11,7 @@ import java.util.Set;
 // NOTE: Since this works like patch is initialising null to all fields reasonable to prevent accidental list overrides
 public class HenkiloForceUpdateDto extends HenkiloUpdateDto {
 
-    private Set<String> yksiloityHetu;
+    private Set<String> kaikkiHetut;
 
     private Boolean turvakielto;
 

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceUpdateDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceUpdateDto.java
@@ -10,6 +10,9 @@ import java.util.Set;
 @Setter
 // NOTE: Since this works like patch is initialising null to all fields reasonable to prevent accidental list overrides
 public class HenkiloForceUpdateDto extends HenkiloUpdateDto {
+
+    private Set<String> yksiloityHetu;
+
     private Boolean turvakielto;
 
     private Set<HuoltajaCreateDto> huoltajat;

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloReadDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloReadDto.java
@@ -15,7 +15,7 @@ public class HenkiloReadDto {
     private LocalDate syntymaaika;
     private LocalDate kuolinpaiva;
     private String hetu;
-    private Set<String> yksiloityHetu;
+    private Set<String> kaikkiHetut;
     private String kutsumanimi;
     private String oidHenkilo;
     private String oppijanumero;

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloReadDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloReadDto.java
@@ -15,6 +15,7 @@ public class HenkiloReadDto {
     private LocalDate syntymaaika;
     private LocalDate kuolinpaiva;
     private String hetu;
+    private Set<String> yksiloityHetu;
     private String kutsumanimi;
     private String oidHenkilo;
     private String oppijanumero;

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/DtoUtils.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/DtoUtils.java
@@ -60,7 +60,7 @@ public class DtoUtils {
         Date createdModified = new Date(29364800000L);
         YhteystiedotRyhmaDto yhteystiedotRyhmaDto = createYhteystiedotRyhmaDto(yhteystietoArvo);
 
-        return new HenkiloDto(oidHenkilo, hetu, passivoitu, etunimet, kutsumanimi, sukunimi,
+        return new HenkiloDto(oidHenkilo, hetu, null, passivoitu, etunimet, kutsumanimi, sukunimi,
                  aidinkieli, aidinkieli, Collections.singleton(aidinkieli), Collections.singleton(kansalaisuus), kasittelija,
                 syntymaAika, "1", null, "1.2.3.4.5", null, false, false, false, false, false, createdModified,
                 createdModified, null, Collections.singleton(yhteystiedotRyhmaDto), new HashSet<>());

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/EntityUtils.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/EntityUtils.java
@@ -84,7 +84,7 @@ public class EntityUtils {
     }
 
     static public Yksilointitieto createYksilointitieto(String etunimet, String kutsumanimi, String sukunimi, String sukupuoli, Henkilo henkilo) {
-        return new Yksilointitieto(henkilo, etunimet, kutsumanimi, sukunimi, sukupuoli, null, false, null,
+        return new Yksilointitieto(henkilo, null, etunimet, kutsumanimi, sukunimi, sukupuoli, null, false, null,
                 Sets.newHashSet(), Sets.newHashSet());
     }
 }

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -15,6 +15,8 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+import static java.util.Arrays.asList;
+
 @Builder(builderClassName = "builder")
 @Getter @Setter
 @NoArgsConstructor
@@ -40,8 +42,23 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
     @Column(name = "oidhenkilo", nullable = false)
     private String oidHenkilo;
 
+    /**
+     * Henkilön nykyinen hetu (voi olla yksilöity tai yksilöimätön).
+     */
     @Column(unique = true)
     private String hetu;
+
+    /**
+     * Henkilön yksilöidyt hetut (nykyinen ja joskus käytössä olleet).
+     */
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "yksiloity_hetu",
+            joinColumns = @JoinColumn(name = "henkilo_id"),
+            foreignKey = @ForeignKey(name = "fk_yksiloity_hetu"),
+            uniqueConstraints = @UniqueConstraint(name = "uk_yksiloity_hetu_01", columnNames = "hetu"))
+    @Column(name = "hetu", nullable = false)
+    @NotAudited
+    private Set<String> yksiloityHetu;
 
     private String etunimet;
 
@@ -257,6 +274,20 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
             return YksilointiTila.VIRHE;
         }
         return YksilointiTila.KESKEN;
+    }
+
+    public boolean addYksiloityHetu(String... hetu) {
+        if (this.yksiloityHetu == null) {
+            this.yksiloityHetu = new HashSet<>();
+        }
+        return this.yksiloityHetu.addAll(asList(hetu));
+    }
+
+    public boolean removeYksiloityHetu(String... hetu) {
+        if (this.yksiloityHetu == null) {
+            this.yksiloityHetu = new HashSet<>();
+        }
+        return this.yksiloityHetu.removeAll(asList(hetu));
     }
 
     // Initialize default values for lombok builder

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -49,16 +49,17 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
     private String hetu;
 
     /**
-     * Henkilön yksilöidyt hetut (nykyinen ja joskus käytössä olleet).
+     * Henkilön kaikki viralliset hetut (nykyinen ja joskus käytössä olleet).
+     * Huom! Ei sisällä yksilöimättömien henkilöiden hetuja.
      */
     @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "yksiloity_hetu",
+    @CollectionTable(name = "henkilo_hetu",
             joinColumns = @JoinColumn(name = "henkilo_id"),
-            foreignKey = @ForeignKey(name = "fk_yksiloity_hetu"),
-            uniqueConstraints = @UniqueConstraint(name = "uk_yksiloity_hetu_01", columnNames = "hetu"))
+            foreignKey = @ForeignKey(name = "fk_henkilo_hetu_henkilo"),
+            uniqueConstraints = @UniqueConstraint(name = "uk_henkilo_hetu_01", columnNames = "hetu"))
     @Column(name = "hetu", nullable = false)
     @NotAudited
-    private Set<String> yksiloityHetu;
+    private Set<String> kaikkiHetut;
 
     private String etunimet;
 
@@ -276,18 +277,18 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
         return YksilointiTila.KESKEN;
     }
 
-    public boolean addYksiloityHetu(String... hetu) {
-        if (this.yksiloityHetu == null) {
-            this.yksiloityHetu = new HashSet<>();
+    public boolean addHetu(String... hetut) {
+        if (this.kaikkiHetut == null) {
+            this.kaikkiHetut = new HashSet<>();
         }
-        return this.yksiloityHetu.addAll(asList(hetu));
+        return this.kaikkiHetut.addAll(asList(hetut));
     }
 
-    public boolean removeYksiloityHetu(String... hetu) {
-        if (this.yksiloityHetu == null) {
-            this.yksiloityHetu = new HashSet<>();
+    public boolean removeHetu(String... hetut) {
+        if (this.kaikkiHetut == null) {
+            this.kaikkiHetut = new HashSet<>();
         }
-        return this.yksiloityHetu.removeAll(asList(hetu));
+        return this.kaikkiHetut.removeAll(asList(hetut));
     }
 
     // Initialize default values for lombok builder

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Yksilointitieto.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Yksilointitieto.java
@@ -22,6 +22,8 @@ public class Yksilointitieto extends IdentifiableAndVersionedEntity {
     @JoinColumn(name = "henkiloid", nullable = false, unique = true)
     private Henkilo henkilo;
 
+    private String hetu;
+
     private String etunimet;
 
     private String kutsumanimi;

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloJpaRepository.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloJpaRepository.java
@@ -77,6 +77,8 @@ public interface HenkiloJpaRepository {
 
     Optional<String> findOidByHetu(String hetu);
 
+    Optional<String> findOidByYksiloityHetu(String hetu);
+
     List<Henkilo> findHenkiloOidHetuNimisByEtunimetOrSukunimi(List<String> etunimet, String sukunimi);
 
     List<YhteystietoHakuDto> findYhteystiedot(YhteystietoCriteria criteria);
@@ -117,6 +119,8 @@ public interface HenkiloJpaRepository {
 
     Optional<HenkiloOidHetuNimiDto> findOidHetuNimiByHetu(String hetu);
 
+    Optional<HenkiloOidHetuNimiDto> findOidHetuNimiByYksiloityHetu(String hetu);
+
     List<Henkilo> findSlavesByMasterOid(String henkiloOid);
 
     List<Henkilo> findDuplikaatit(HenkiloDuplikaattiCriteria criteria);
@@ -126,6 +130,8 @@ public interface HenkiloJpaRepository {
     Iterable<String> findOidByYhteystieto(String arvo);
 
     Iterable<String> findPassinumerotByOid(String oid);
+
+    Map<String, Henkilo> findAndMapByYksiloityHetu(Set<String> hetut);
 
     Map<String, Henkilo> findAndMapByPassinumerot(Set<String> passinumerot);
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloJpaRepository.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloJpaRepository.java
@@ -77,7 +77,7 @@ public interface HenkiloJpaRepository {
 
     Optional<String> findOidByHetu(String hetu);
 
-    Optional<String> findOidByYksiloityHetu(String hetu);
+    Optional<String> findOidByKaikkiHetut(String hetu);
 
     List<Henkilo> findHenkiloOidHetuNimisByEtunimetOrSukunimi(List<String> etunimet, String sukunimi);
 
@@ -119,7 +119,7 @@ public interface HenkiloJpaRepository {
 
     Optional<HenkiloOidHetuNimiDto> findOidHetuNimiByHetu(String hetu);
 
-    Optional<HenkiloOidHetuNimiDto> findOidHetuNimiByYksiloityHetu(String hetu);
+    Optional<HenkiloOidHetuNimiDto> findOidHetuNimiByKaikkiHetut(String hetu);
 
     List<Henkilo> findSlavesByMasterOid(String henkiloOid);
 
@@ -131,7 +131,7 @@ public interface HenkiloJpaRepository {
 
     Iterable<String> findPassinumerotByOid(String oid);
 
-    Map<String, Henkilo> findAndMapByYksiloityHetu(Set<String> hetut);
+    Map<String, Henkilo> findAndMapByKaikkiHetut(Set<String> hetut);
 
     Map<String, Henkilo> findAndMapByPassinumerot(Set<String> passinumerot);
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloRepository.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloRepository.java
@@ -1,21 +1,16 @@
 package fi.vm.sade.oppijanumerorekisteri.repositories;
 
 import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
-import java.util.Collection;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 // Note: can return only Henkilo objects
-@Transactional(propagation = Propagation.MANDATORY)
-@Repository
 public interface HenkiloRepository extends QuerydslPredicateExecutor, JpaRepository<Henkilo, Long>, HenkiloJpaRepository {
     @EntityGraph("henkiloDto")
     List<Henkilo> findByOidHenkiloIsIn(Collection<String> oidHenkilo);
@@ -23,6 +18,8 @@ public interface HenkiloRepository extends QuerydslPredicateExecutor, JpaReposit
     Optional<Henkilo> findByOidHenkilo(String henkiloOid);
 
     Optional<Henkilo> findByHetu(String hetu);
+
+    Optional<Henkilo> findByYksiloityHetu(String hetu);
 
     List<Henkilo> findByHetuIn(Set<String> hetut);
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloRepository.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HenkiloRepository.java
@@ -19,7 +19,7 @@ public interface HenkiloRepository extends QuerydslPredicateExecutor, JpaReposit
 
     Optional<Henkilo> findByHetu(String hetu);
 
-    Optional<Henkilo> findByYksiloityHetu(String hetu);
+    Optional<Henkilo> findByKaikkiHetut(String hetu);
 
     List<Henkilo> findByHetuIn(Set<String> hetut);
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HetuRepository.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/HetuRepository.java
@@ -4,7 +4,12 @@ import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 
 import java.util.Collection;
 
-public interface YksiloityHetuRepository {
+/**
+ * Tietokantakyselyt henkilöiden virallisten hetujen listaamiseen.
+ *
+ * Huom! Ei palauta yksilöimättömien henkilöiden hetuja.
+ */
+public interface HetuRepository {
 
     Collection<String> findAll();
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/YksiloityHetuRepository.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/YksiloityHetuRepository.java
@@ -1,0 +1,15 @@
+package fi.vm.sade.oppijanumerorekisteri.repositories;
+
+import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
+
+import java.util.Collection;
+
+public interface YksiloityHetuRepository {
+
+    Collection<String> findAll();
+
+    Collection<String> findByHenkilo(Henkilo henkilo);
+
+    Collection<String> findByHenkiloOid(String oid);
+
+}

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
@@ -182,6 +182,16 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
     }
 
     @Override
+    public Optional<String> findOidByYksiloityHetu(String hetu) {
+        QHenkilo qHenkilo = QHenkilo.henkilo;
+        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+        return Optional.ofNullable(jpa().select(qHenkilo.oidHenkilo).from(qHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
+                .where(qYksiloityHetu.eq(hetu))
+                .fetchOne());
+    }
+
+    @Override
     public List<Henkilo> findHenkiloOidHetuNimisByEtunimetOrSukunimi(List<String> etunimet, String sukunimi) {
         JPAQuery<Henkilo> query = jpa().select(Projections.bean(Henkilo.class, henkilo.oidHenkilo, henkilo.etunimet,
                 henkilo.kutsumanimi, henkilo.sukunimi, henkilo.hetu))
@@ -429,6 +439,22 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
     }
 
     @Override
+    public Optional<HenkiloOidHetuNimiDto> findOidHetuNimiByYksiloityHetu(String hetu) {
+        QHenkilo qHenkilo = QHenkilo.henkilo;
+        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+
+        return Optional.ofNullable(jpa().from(qHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHetu).where(qYksiloityHetu.eq(hetu))
+                .select(Projections.bean(HenkiloOidHetuNimiDto.class,
+                        qHenkilo.oidHenkilo,
+                        qHenkilo.hetu,
+                        qHenkilo.etunimet,
+                        qHenkilo.kutsumanimi,
+                        qHenkilo.sukunimi))
+                .fetchOne());
+    }
+
+    @Override
     public List<Henkilo> findSlavesByMasterOid(String henkiloOid) {
         QHenkilo qMaster = new QHenkilo("master");
         QHenkilo qSlave = new QHenkilo("slave");
@@ -505,6 +531,18 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
                 .where(qHenkilo.oidHenkilo.eq(oid))
                 .select(qPassinumero)
                 .fetch();
+    }
+
+    @Override
+    public Map<String, Henkilo> findAndMapByYksiloityHetu(Set<String> hetut) {
+        QHenkilo qHenkilo = QHenkilo.henkilo;
+        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+
+        return jpa()
+                .from(qHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
+                .where(qYksiloityHetu.in(hetut))
+                .transform(groupBy(qYksiloityHetu).as(qHenkilo));
     }
 
     @Override

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HenkiloRepositoryImpl.java
@@ -182,12 +182,12 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
     }
 
     @Override
-    public Optional<String> findOidByYksiloityHetu(String hetu) {
+    public Optional<String> findOidByKaikkiHetut(String hetu) {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+        StringPath qHetu = Expressions.stringPath("kaikkiHetut");
         return Optional.ofNullable(jpa().select(qHenkilo.oidHenkilo).from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
-                .where(qYksiloityHetu.eq(hetu))
+                .join(qHenkilo.kaikkiHetut, qHetu)
+                .where(qHetu.eq(hetu))
                 .fetchOne());
     }
 
@@ -439,12 +439,12 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
     }
 
     @Override
-    public Optional<HenkiloOidHetuNimiDto> findOidHetuNimiByYksiloityHetu(String hetu) {
+    public Optional<HenkiloOidHetuNimiDto> findOidHetuNimiByKaikkiHetut(String hetu) {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+        StringPath qHetu = Expressions.stringPath("kaikkiHetut");
 
         return Optional.ofNullable(jpa().from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHetu).where(qYksiloityHetu.eq(hetu))
+                .join(qHenkilo.kaikkiHetut, qHetu).where(qHetu.eq(hetu))
                 .select(Projections.bean(HenkiloOidHetuNimiDto.class,
                         qHenkilo.oidHenkilo,
                         qHenkilo.hetu,
@@ -534,15 +534,15 @@ public class HenkiloRepositoryImpl implements HenkiloJpaRepository {
     }
 
     @Override
-    public Map<String, Henkilo> findAndMapByYksiloityHetu(Set<String> hetut) {
+    public Map<String, Henkilo> findAndMapByKaikkiHetut(Set<String> hetut) {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+        StringPath qHetu = Expressions.stringPath("kaikkiHetut");
 
         return jpa()
                 .from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
-                .where(qYksiloityHetu.in(hetut))
-                .transform(groupBy(qYksiloityHetu).as(qHenkilo));
+                .join(qHenkilo.kaikkiHetut, qHetu)
+                .where(qHetu.in(hetut))
+                .transform(groupBy(qHetu).as(qHenkilo));
     }
 
     @Override

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HetuRepositoryImpl.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/HetuRepositoryImpl.java
@@ -5,7 +5,7 @@ import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.models.QHenkilo;
-import fi.vm.sade.oppijanumerorekisteri.repositories.YksiloityHetuRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HetuRepository;
 import org.springframework.data.jpa.repository.JpaContext;
 import org.springframework.stereotype.Repository;
 
@@ -13,46 +13,46 @@ import javax.persistence.EntityManager;
 import java.util.Collection;
 
 @Repository
-public class YksiloityHetuRepositoryImpl implements YksiloityHetuRepository {
+public class HetuRepositoryImpl implements HetuRepository {
 
     private final EntityManager entityManager;
 
-    public YksiloityHetuRepositoryImpl(JpaContext jpaContext) {
+    public HetuRepositoryImpl(JpaContext jpaContext) {
         this.entityManager = jpaContext.getEntityManagerByManagedType(Henkilo.class);
     }
 
     @Override
     public Collection<String> findAll() {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+        StringPath qHetu = Expressions.stringPath("kaikkiHetut");
         return new JPAQuery<>(entityManager)
                 .from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
-                .select(qYksiloityHetu)
+                .join(qHenkilo.kaikkiHetut, qHetu)
+                .select(qHetu)
                 .fetch();
     }
 
     @Override
     public Collection<String> findByHenkilo(Henkilo henkilo) {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+        StringPath qHetu = Expressions.stringPath("kaikkiHetut");
         return new JPAQuery<>(entityManager)
                 .from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
+                .join(qHenkilo.kaikkiHetut, qHetu)
                 .where(qHenkilo.eq(henkilo))
-                .select(qYksiloityHetu)
+                .select(qHetu)
                 .fetch();
     }
 
     @Override
     public Collection<String> findByHenkiloOid(String oid) {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
+        StringPath qHetu = Expressions.stringPath("kaikkiHetut");
         return new JPAQuery<>(entityManager)
                 .from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
+                .join(qHenkilo.kaikkiHetut, qHetu)
                 .where(qHenkilo.oidHenkilo.eq(oid))
-                .select(qYksiloityHetu)
+                .select(qHetu)
                 .fetch();
     }
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/YksiloityHetuRepositoryImpl.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/YksiloityHetuRepositoryImpl.java
@@ -24,35 +24,35 @@ public class YksiloityHetuRepositoryImpl implements YksiloityHetuRepository {
     @Override
     public Collection<String> findAll() {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHenkilo = Expressions.stringPath("yksiloityHetu");
+        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
         return new JPAQuery<>(entityManager)
                 .from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHenkilo)
-                .select(qYksiloityHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
+                .select(qYksiloityHetu)
                 .fetch();
     }
 
     @Override
     public Collection<String> findByHenkilo(Henkilo henkilo) {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHenkilo = Expressions.stringPath("yksiloityHetu");
+        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
         return new JPAQuery<>(entityManager)
                 .from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
                 .where(qHenkilo.eq(henkilo))
-                .select(qYksiloityHenkilo)
+                .select(qYksiloityHetu)
                 .fetch();
     }
 
     @Override
     public Collection<String> findByHenkiloOid(String oid) {
         QHenkilo qHenkilo = QHenkilo.henkilo;
-        StringPath qYksiloityHenkilo = Expressions.stringPath("yksiloityHetu");
+        StringPath qYksiloityHetu = Expressions.stringPath("yksiloityHetu");
         return new JPAQuery<>(entityManager)
                 .from(qHenkilo)
-                .join(qHenkilo.yksiloityHetu, qYksiloityHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHetu)
                 .where(qHenkilo.oidHenkilo.eq(oid))
-                .select(qYksiloityHenkilo)
+                .select(qYksiloityHetu)
                 .fetch();
     }
 

--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/YksiloityHetuRepositoryImpl.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/repositories/impl/YksiloityHetuRepositoryImpl.java
@@ -1,0 +1,59 @@
+package fi.vm.sade.oppijanumerorekisteri.repositories.impl;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
+import fi.vm.sade.oppijanumerorekisteri.models.QHenkilo;
+import fi.vm.sade.oppijanumerorekisteri.repositories.YksiloityHetuRepository;
+import org.springframework.data.jpa.repository.JpaContext;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.Collection;
+
+@Repository
+public class YksiloityHetuRepositoryImpl implements YksiloityHetuRepository {
+
+    private final EntityManager entityManager;
+
+    public YksiloityHetuRepositoryImpl(JpaContext jpaContext) {
+        this.entityManager = jpaContext.getEntityManagerByManagedType(Henkilo.class);
+    }
+
+    @Override
+    public Collection<String> findAll() {
+        QHenkilo qHenkilo = QHenkilo.henkilo;
+        StringPath qYksiloityHenkilo = Expressions.stringPath("yksiloityHetu");
+        return new JPAQuery<>(entityManager)
+                .from(qHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHenkilo)
+                .select(qYksiloityHenkilo)
+                .fetch();
+    }
+
+    @Override
+    public Collection<String> findByHenkilo(Henkilo henkilo) {
+        QHenkilo qHenkilo = QHenkilo.henkilo;
+        StringPath qYksiloityHenkilo = Expressions.stringPath("yksiloityHetu");
+        return new JPAQuery<>(entityManager)
+                .from(qHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHenkilo)
+                .where(qHenkilo.eq(henkilo))
+                .select(qYksiloityHenkilo)
+                .fetch();
+    }
+
+    @Override
+    public Collection<String> findByHenkiloOid(String oid) {
+        QHenkilo qHenkilo = QHenkilo.henkilo;
+        StringPath qYksiloityHenkilo = Expressions.stringPath("yksiloityHetu");
+        return new JPAQuery<>(entityManager)
+                .from(qHenkilo)
+                .join(qHenkilo.yksiloityHetu, qYksiloityHenkilo)
+                .where(qHenkilo.oidHenkilo.eq(oid))
+                .select(qYksiloityHenkilo)
+                .fetch();
+    }
+
+}

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/DuplicateService.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/DuplicateService.java
@@ -17,6 +17,8 @@ public interface DuplicateService {
 
     void removeDuplicateHetuAndLink(String oidHenkilo, String hetu);
 
+    Henkilo linkWithHetu(Henkilo henkilo, String hetu);
+
     List<String> linkHenkilos(String henkiloOid, List<String> similarHenkiloOids);
 
     void unlinkHenkilo(String oid, String slaveOid);

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
@@ -18,6 +18,7 @@ import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.KansalaisuusRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.KielisyysRepository;
 import fi.vm.sade.oppijanumerorekisteri.services.*;
+import fi.vm.sade.oppijanumerorekisteri.utils.OptionalUtils;
 import fi.vm.sade.oppijanumerorekisteri.validation.HetuUtils;
 import fi.vm.sade.oppijanumerorekisteri.validators.HenkiloCreatePostValidator;
 import fi.vm.sade.oppijanumerorekisteri.validators.HenkiloUpdatePostValidator;
@@ -186,7 +187,8 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
     public Henkilo findOrCreateHuoltaja(HuoltajaCreateDto huoltajaCreateDto, Henkilo lapsi) {
         Optional<Henkilo> huoltaja = Optional.empty();
         if (StringUtils.hasLength(huoltajaCreateDto.getHetu())) {
-            huoltaja = this.henkiloDataRepository.findByHetu(huoltajaCreateDto.getHetu());
+            huoltaja = OptionalUtils.or(this.henkiloDataRepository.findByHetu(huoltajaCreateDto.getHetu()),
+                    () -> this.henkiloDataRepository.findByYksiloityHetu(huoltajaCreateDto.getHetu()));
         }
         else if (StringUtils.hasLength(huoltajaCreateDto.getEtunimet()) && StringUtils.hasLength(huoltajaCreateDto.getSukunimi())) {
             huoltaja = lapsi.getHuoltajat().stream()
@@ -206,6 +208,13 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
     private void updateHetuAndLinkDuplicate(HenkiloForceUpdateDto henkiloUpdateDto, Henkilo henkiloSaved) {
         // Only if hetu has changed
         if (StringUtils.hasLength(henkiloUpdateDto.getHetu()) && !henkiloUpdateDto.getHetu().equals(henkiloSaved.getHetu())) {
+            if (henkiloSaved.isYksiloityVTJ()) {
+                henkiloDataRepository.findByHetu(henkiloUpdateDto.getHetu()).ifPresent(henkiloByUusiHetu -> {
+                    henkiloByUusiHetu.removeYksiloityHetu(henkiloUpdateDto.getHetu());
+                    henkiloDataRepository.saveAndFlush(henkiloByUusiHetu);
+                });
+                henkiloSaved.addYksiloityHetu(henkiloUpdateDto.getHetu());
+            }
             String newHetu = henkiloUpdateDto.getHetu();
             this.duplicateService.removeDuplicateHetuAndLink(henkiloUpdateDto.getOidHenkilo(), newHetu);
             henkiloSaved.setHetu(newHetu);
@@ -322,7 +331,8 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
                 dto -> Optional.ofNullable(dto.getIdentifications())
                         .filter(identifications -> !identifications.isEmpty())
                         .flatMap(identifications -> findUnique(henkiloDataRepository.findByIdentifications(identifications))),
-                dto -> Optional.ofNullable(dto.getHetu()).flatMap(henkiloDataRepository::findByHetu)
+                dto -> Optional.ofNullable(dto.getHetu()).flatMap(hetu -> OptionalUtils.or(
+                        henkiloDataRepository.findByHetu(hetu), () -> henkiloDataRepository.findByYksiloityHetu(hetu)))
         ).map(transformer -> transformer.apply(henkiloPerustietoDto))
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
@@ -188,7 +188,7 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
         Optional<Henkilo> huoltaja = Optional.empty();
         if (StringUtils.hasLength(huoltajaCreateDto.getHetu())) {
             huoltaja = OptionalUtils.or(this.henkiloDataRepository.findByHetu(huoltajaCreateDto.getHetu()),
-                    () -> this.henkiloDataRepository.findByYksiloityHetu(huoltajaCreateDto.getHetu()));
+                    () -> this.henkiloDataRepository.findByKaikkiHetut(huoltajaCreateDto.getHetu()));
         }
         else if (StringUtils.hasLength(huoltajaCreateDto.getEtunimet()) && StringUtils.hasLength(huoltajaCreateDto.getSukunimi())) {
             huoltaja = lapsi.getHuoltajat().stream()
@@ -210,10 +210,10 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
         if (StringUtils.hasLength(henkiloUpdateDto.getHetu()) && !henkiloUpdateDto.getHetu().equals(henkiloSaved.getHetu())) {
             if (henkiloSaved.isYksiloityVTJ()) {
                 henkiloDataRepository.findByHetu(henkiloUpdateDto.getHetu()).ifPresent(henkiloByUusiHetu -> {
-                    henkiloByUusiHetu.removeYksiloityHetu(henkiloUpdateDto.getHetu());
+                    henkiloByUusiHetu.removeHetu(henkiloUpdateDto.getHetu());
                     henkiloDataRepository.saveAndFlush(henkiloByUusiHetu);
                 });
-                henkiloSaved.addYksiloityHetu(henkiloUpdateDto.getHetu());
+                henkiloSaved.addHetu(henkiloUpdateDto.getHetu());
             }
             String newHetu = henkiloUpdateDto.getHetu();
             this.duplicateService.removeDuplicateHetuAndLink(henkiloUpdateDto.getOidHenkilo(), newHetu);
@@ -332,7 +332,7 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
                         .filter(identifications -> !identifications.isEmpty())
                         .flatMap(identifications -> findUnique(henkiloDataRepository.findByIdentifications(identifications))),
                 dto -> Optional.ofNullable(dto.getHetu()).flatMap(hetu -> OptionalUtils.or(
-                        henkiloDataRepository.findByHetu(hetu), () -> henkiloDataRepository.findByYksiloityHetu(hetu)))
+                        henkiloDataRepository.findByHetu(hetu), () -> henkiloDataRepository.findByKaikkiHetut(hetu)))
         ).map(transformer -> transformer.apply(henkiloPerustietoDto))
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
@@ -199,7 +199,7 @@ public class HenkiloServiceImpl implements HenkiloService {
     @Transactional(readOnly = true)
     public String getOidByHetu(String hetu) {
         return OptionalUtils.or(this.henkiloDataRepository.findOidByHetu(hetu),
-                () -> this.henkiloDataRepository.findOidByYksiloityHetu(hetu))
+                () -> this.henkiloDataRepository.findOidByKaikkiHetut(hetu))
                 .orElseThrow(NotFoundException::new);
     }
 
@@ -232,7 +232,7 @@ public class HenkiloServiceImpl implements HenkiloService {
     @Transactional(readOnly = true)
     public HenkiloOidHetuNimiDto getHenkiloOidHetuNimiByHetu(String hetu) {
         return OptionalUtils.or(henkiloDataRepository.findOidHetuNimiByHetu(hetu),
-                () -> henkiloDataRepository.findOidHetuNimiByYksiloityHetu(hetu))
+                () -> henkiloDataRepository.findOidHetuNimiByKaikkiHetut(hetu))
                 .orElseThrow(NotFoundException::new);
     }
 
@@ -339,7 +339,7 @@ public class HenkiloServiceImpl implements HenkiloService {
     @Transactional(readOnly = true)
     public HenkiloReadDto getByHetu(String hetu) {
         Henkilo henkilo = OptionalUtils.or(henkiloDataRepository.findByHetu(hetu),
-                () -> henkiloDataRepository.findByYksiloityHetu(hetu))
+                () -> henkiloDataRepository.findByKaikkiHetut(hetu))
                 .orElseThrow(() -> new NotFoundException("Henkilöä ei löytynyt henkilötunnuksella " + hetu));
         return mapper.map(henkilo, HenkiloReadDto.class);
     }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
@@ -22,6 +22,7 @@ import fi.vm.sade.oppijanumerorekisteri.services.HenkiloService;
 import fi.vm.sade.oppijanumerorekisteri.services.PermissionChecker;
 import fi.vm.sade.oppijanumerorekisteri.services.UserDetailsHelper;
 import fi.vm.sade.oppijanumerorekisteri.services.convert.YhteystietoConverter;
+import fi.vm.sade.oppijanumerorekisteri.utils.OptionalUtils;
 import lombok.RequiredArgsConstructor;
 import ma.glasnost.orika.metadata.TypeBuilder;
 import org.joda.time.DateTime;
@@ -197,7 +198,9 @@ public class HenkiloServiceImpl implements HenkiloService {
     @Override
     @Transactional(readOnly = true)
     public String getOidByHetu(String hetu) {
-        return this.henkiloDataRepository.findOidByHetu(hetu).orElseThrow(NotFoundException::new);
+        return OptionalUtils.or(this.henkiloDataRepository.findOidByHetu(hetu),
+                () -> this.henkiloDataRepository.findOidByYksiloityHetu(hetu))
+                .orElseThrow(NotFoundException::new);
     }
 
     @Override
@@ -228,7 +231,9 @@ public class HenkiloServiceImpl implements HenkiloService {
     @Override
     @Transactional(readOnly = true)
     public HenkiloOidHetuNimiDto getHenkiloOidHetuNimiByHetu(String hetu) {
-        return henkiloDataRepository.findOidHetuNimiByHetu(hetu).orElseThrow(NotFoundException::new);
+        return OptionalUtils.or(henkiloDataRepository.findOidHetuNimiByHetu(hetu),
+                () -> henkiloDataRepository.findOidHetuNimiByYksiloityHetu(hetu))
+                .orElseThrow(NotFoundException::new);
     }
 
     @Override
@@ -333,7 +338,8 @@ public class HenkiloServiceImpl implements HenkiloService {
     @Override
     @Transactional(readOnly = true)
     public HenkiloReadDto getByHetu(String hetu) {
-        Henkilo henkilo = henkiloDataRepository.findByHetu(hetu)
+        Henkilo henkilo = OptionalUtils.or(henkiloDataRepository.findByHetu(hetu),
+                () -> henkiloDataRepository.findByYksiloityHetu(hetu))
                 .orElseThrow(() -> new NotFoundException("Henkilöä ei löytynyt henkilötunnuksella " + hetu));
         return mapper.map(henkilo, HenkiloReadDto.class);
     }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/OppijaTuontiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/OppijaTuontiServiceImpl.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindException;
-import org.springframework.validation.Errors;
 
 import java.io.IOException;
 import java.util.*;
@@ -165,7 +164,7 @@ public class OppijaTuontiServiceImpl implements OppijaTuontiService {
         Map<String, Henkilo> henkilotByHetu = henkiloRepository
                 .findByHetuIn(hetut).stream()
                 .collect(toMap(Henkilo::getHetu, identity()));
-        henkilotByHetu.putAll(henkiloRepository.findAndMapByYksiloityHetu(hetut));
+        henkilotByHetu.putAll(henkiloRepository.findAndMapByKaikkiHetut(hetut));
         return henkilotByHetu;
     }
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/OppijaTuontiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/OppijaTuontiServiceImpl.java
@@ -139,9 +139,7 @@ public class OppijaTuontiServiceImpl implements OppijaTuontiService {
                 .map(t -> t.getHenkilo().getHetu())
                 .filter(Objects::nonNull)
                 .collect(toSet());
-        Map<String, Henkilo> henkilotByHetu = hetut.isEmpty() ? emptyMap() : henkiloRepository
-                .findByHetuIn(hetut).stream()
-                .collect(toMap(Henkilo::getHetu, identity()));
+        Map<String, Henkilo> henkilotByHetu = hetut.isEmpty() ? emptyMap() : getHenkilotByHetu(hetut);
         // passinumerot
         Set<String> passinumerot = henkilot.stream()
                 .map(t -> t.getHenkilo().getPassinumero())
@@ -161,6 +159,14 @@ public class OppijaTuontiServiceImpl implements OppijaTuontiService {
         return henkilot.stream()
                 .map(tuontiRiviMapper::map)
                 .collect(toSet());
+    }
+
+    private Map<String, Henkilo> getHenkilotByHetu(Set<String> hetut) {
+        Map<String, Henkilo> henkilotByHetu = henkiloRepository
+                .findByHetuIn(hetut).stream()
+                .collect(toMap(Henkilo::getHetu, identity()));
+        henkilotByHetu.putAll(henkiloRepository.findAndMapByYksiloityHetu(hetut));
+        return henkilotByHetu;
     }
 
     @RequiredArgsConstructor

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
@@ -357,10 +357,10 @@ public class YksilointiServiceImpl implements YksilointiService {
                 return false;
             }
             henkilo.setHetu(uusiHetu);
-            henkilo.addYksiloityHetu(uusiHetu);
+            henkilo.addHetu(uusiHetu);
         }
 
-        henkilo.addYksiloityHetu(nykyinenHetu);
+        henkilo.addHetu(nykyinenHetu);
         henkilo.setOppijanumero(henkilo.getOidHenkilo());
 
         updateIfYksiloityValueNotNull(henkilo.getEtunimet(), yksiloityHenkilo.getEtunimi(),henkilo::setEtunimet);
@@ -416,8 +416,8 @@ public class YksilointiServiceImpl implements YksilointiService {
     private boolean kasitteleHetuMuutos(Henkilo henkilo, String nykyinenHetu, String uusiHetu) {
         Henkilo master = duplicateService.linkWithHetu(henkilo, uusiHetu);
         if (!master.equals(henkilo)) {
-            henkilo.removeYksiloityHetu(nykyinenHetu, uusiHetu);
-            master.addYksiloityHetu(nykyinenHetu, uusiHetu);
+            henkilo.removeHetu(nykyinenHetu, uusiHetu);
+            master.addHetu(nykyinenHetu, uusiHetu);
             return true;
         }
         return false;
@@ -516,10 +516,10 @@ public class YksilointiServiceImpl implements YksilointiService {
                 return;
             }
             henkilo.setHetu(uusiHetu);
-            henkilo.addYksiloityHetu(uusiHetu);
+            henkilo.addHetu(uusiHetu);
         }
 
-        henkilo.addYksiloityHetu(nykyinenHetu);
+        henkilo.addHetu(nykyinenHetu);
         henkilo.setOppijanumero(henkilo.getOidHenkilo());
         henkilo.setEtunimet(yksilointitieto.getEtunimet());
         henkilo.setSukunimi(yksilointitieto.getSukunimi());

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
@@ -174,6 +174,7 @@ public class YksilointiServiceImpl implements YksilointiService {
 
         if (this.yhtenevyysTarkistus(henkilo, yksiloityHenkilo)) {
             this.addYksilointitietosWhenNamesDoNotMatch(henkilo, yksiloityHenkilo);
+            return henkiloModificationService.update(henkilo);
         }
         else {
             logger.info("Henkilön yksilöinti onnistui hetulle: {}", henkilo.getHetu());
@@ -186,10 +187,11 @@ public class YksilointiServiceImpl implements YksilointiService {
                 henkilo.setYksiloity(false);
 
                 yksilointitietoRepository.findByHenkilo(henkilo).ifPresent(yksilointitietoRepository::delete);
+                return henkiloModificationService.update(henkilo);
             }
         }
 
-        return henkiloModificationService.update(henkilo);
+        return henkilo;
     }
 
     // Palauttaa tiedon ovatko henkilön nimet epävastaavia VTJ-datan kanssa.
@@ -487,8 +489,8 @@ public class YksilointiServiceImpl implements YksilointiService {
         logger.info("Päivitetään tiedot VTJ:stä hetulle: {}", hetu);
         if (this.paivitaHenkilonTiedotVTJnTiedoilla(henkilo, yksiloityHenkilo)) {
             henkilo.setVtjsynced(new Date());
+            henkiloModificationService.update(henkilo);
         }
-        henkiloModificationService.update(henkilo);
     }
 
     @Override

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
@@ -522,7 +522,11 @@ public class YksilointiServiceImpl implements YksilointiService {
         henkilo.setOppijanumero(henkilo.getOidHenkilo());
         henkilo.setEtunimet(yksilointitieto.getEtunimet());
         henkilo.setSukunimi(yksilointitieto.getSukunimi());
+        if (HetuUtils.hetuIsValid(uusiHetu)) {
+            henkilo.setSyntymaaika(HetuUtils.dateFromHetu(uusiHetu));
+        }
         henkilo.setSukupuoli(yksilointitieto.getSukupuoli());
+
         henkilo.setKotikunta(yksilointitieto.getKotikunta());
         henkilo.setYksiloityVTJ(true);
         henkilo.setYksiloity(false);

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
@@ -178,7 +178,6 @@ public class YksilointiServiceImpl implements YksilointiService {
         else {
             logger.info("Henkilön yksilöinti onnistui hetulle: {}", henkilo.getHetu());
 
-            henkilo.setOppijanumero(henkilo.getOidHenkilo());
             // If VTJ data differs from the user's data, VTJ must overwrite
             // those values since VTJ's data is considered more reliable
             if (this.paivitaHenkilonTiedotVTJnTiedoilla(henkilo, yksiloityHenkilo)) {

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/OptionalUtils.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/OptionalUtils.java
@@ -1,0 +1,16 @@
+package fi.vm.sade.oppijanumerorekisteri.utils;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public final class OptionalUtils {
+
+    private OptionalUtils() {
+    }
+
+    // tämän metodin voi poistaa java9+ (käytä Optional#or)
+    public static <T> Optional<T> or(Optional<T> optional, Supplier<Optional<T>> fallback) {
+        return optional.isPresent() ? optional : fallback.get();
+    }
+
+}

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloCreatePostValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloCreatePostValidator.java
@@ -43,7 +43,7 @@ public class HenkiloCreatePostValidator implements Validator {
         String hetu = henkilo.getHetu();
         if (!StringUtils.isEmpty(hetu)) {
             Stream<Function<String, Optional<Henkilo>>> findByHetuFunctions = Stream
-                    .of(henkiloRepository::findByHetu, henkiloRepository::findByYksiloityHetu);
+                    .of(henkiloRepository::findByHetu, henkiloRepository::findByKaikkiHetut);
             findByHetuFunctions.forEach(findByHetuFun -> findByHetuFun.apply(hetu).ifPresent(henkiloByHetu
                     -> errors.rejectValue("hetu", "socialsecuritynr.already.exists")));
         }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloUpdatePostValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloUpdatePostValidator.java
@@ -15,7 +15,10 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -116,11 +119,13 @@ public class HenkiloUpdatePostValidator implements Validator {
                 errors.rejectValue("hetu", "socialsecuritynr.already.set");
             } else if (!StringUtils.isEmpty(dto.getHetu())) {
                 // tarkistetaan että hetu on uniikki
-                henkiloRepository.findByHetu(dto.getHetu()).ifPresent(henkiloByHetu -> {
+                Stream<Function<String, Optional<Henkilo>>> findByHetuFunctions = Stream
+                        .of(henkiloRepository::findByHetu, henkiloRepository::findByYksiloityHetu);
+                findByHetuFunctions.forEach(findByHetuFun -> findByHetuFun.apply(dto.getHetu()).ifPresent(henkiloByHetu -> {
                     if (!henkiloByHetu.getOidHenkilo().equals(dto.getOidHenkilo())) {
                         errors.rejectValue("hetu", "socialsecuritynr.already.exists");
                     }
-                });
+                }));
             }
         }
     }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloUpdatePostValidator.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/validators/HenkiloUpdatePostValidator.java
@@ -120,7 +120,7 @@ public class HenkiloUpdatePostValidator implements Validator {
             } else if (!StringUtils.isEmpty(dto.getHetu())) {
                 // tarkistetaan että hetu on uniikki
                 Stream<Function<String, Optional<Henkilo>>> findByHetuFunctions = Stream
-                        .of(henkiloRepository::findByHetu, henkiloRepository::findByYksiloityHetu);
+                        .of(henkiloRepository::findByHetu, henkiloRepository::findByKaikkiHetut);
                 findByHetuFunctions.forEach(findByHetuFun -> findByHetuFun.apply(dto.getHetu()).ifPresent(henkiloByHetu -> {
                     if (!henkiloByHetu.getOidHenkilo().equals(dto.getOidHenkilo())) {
                         errors.rejectValue("hetu", "socialsecuritynr.already.exists");

--- a/oppijanumerorekisteri-service/src/main/resources/db/migration/V20181031113859023__hetuhistoria.sql
+++ b/oppijanumerorekisteri-service/src/main/resources/db/migration/V20181031113859023__hetuhistoria.sql
@@ -1,0 +1,18 @@
+create table yksiloity_hetu (
+    henkilo_id int8 not null,
+    hetu varchar(255) not null,
+    primary key (henkilo_id, hetu)
+);
+
+insert into yksiloity_hetu (henkilo_id, hetu)
+select id, hetu from henkilo where hetu is not null and yksiloityvtj = true;
+
+alter table yksiloity_hetu
+    add constraint uk_yksiloity_hetu_01 unique (hetu);
+
+alter table yksiloity_hetu
+    add constraint fk_yksiloity_hetu
+    foreign key (henkilo_id)
+    references public.henkilo;
+
+alter table yksilointitieto add column hetu varchar(255);

--- a/oppijanumerorekisteri-service/src/main/resources/db/migration/V20181031113859023__hetuhistoria.sql
+++ b/oppijanumerorekisteri-service/src/main/resources/db/migration/V20181031113859023__hetuhistoria.sql
@@ -1,17 +1,17 @@
-create table yksiloity_hetu (
+create table henkilo_hetu (
     henkilo_id int8 not null,
     hetu varchar(255) not null,
     primary key (henkilo_id, hetu)
 );
 
-insert into yksiloity_hetu (henkilo_id, hetu)
+insert into henkilo_hetu (henkilo_id, hetu)
 select id, hetu from henkilo where hetu is not null and yksiloityvtj = true;
 
-alter table yksiloity_hetu
-    add constraint uk_yksiloity_hetu_01 unique (hetu);
+alter table henkilo_hetu
+    add constraint uk_henkilo_hetu_01 unique (hetu);
 
-alter table yksiloity_hetu
-    add constraint fk_yksiloity_hetu
+alter table henkilo_hetu
+    add constraint fk_henkilo_hetu_henkilo
     foreign key (henkilo_id)
     references public.henkilo;
 

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
@@ -104,6 +104,24 @@ public class HenkiloModificationServiceIntegrationTest {
 
     @Test
     @WithMockUser(roles = "APP_HENKILONHALLINTA_OPHREKISTERI")
+    public void yksiloityHetuAddedOnHetuChange() {
+        HenkiloForceUpdateDto updateDto = new HenkiloForceUpdateDto();
+        updateDto.setOidHenkilo("VTJYKSILOITY1");
+        updateDto.setHetu("170775-973B");
+
+        henkiloModificationService.forceUpdateHenkilo(updateDto);
+        Henkilo henkilo = this.entityManager
+                .createQuery("SELECT h FROM Henkilo h WHERE h.oidHenkilo='VTJYKSILOITY1'", Henkilo.class)
+                .getSingleResult();
+
+        assertThat(henkilo)
+                .extracting(Henkilo::getOidHenkilo, Henkilo::getHetu, Henkilo::isYksilointiYritetty)
+                .containsExactly("VTJYKSILOITY1", "170775-973B", false);
+        assertThat(henkilo.getYksiloityHetu()).containsExactlyInAnyOrder("111111-985K", "170775-973B");
+    }
+
+    @Test
+    @WithMockUser(roles = "APP_HENKILONHALLINTA_OPHREKISTERI")
     public void yksilointivirheRemovedOnHetuChange() {
         HenkiloUpdateDto updateDto = new HenkiloUpdateDto();
         updateDto.setOidHenkilo("YKSILOINNISSAVIRHE");

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
@@ -106,10 +106,10 @@ public class HenkiloModificationServiceIntegrationTest {
 
     @Test
     @WithMockUser(roles = "APP_HENKILONHALLINTA_OPHREKISTERI")
-    public void yksiloityHetuAdded() {
+    public void kaikkiHetutAdded() {
         HenkiloForceUpdateDto updateDto = new HenkiloForceUpdateDto();
         updateDto.setOidHenkilo("VTJYKSILOITY1");
-        updateDto.setYksiloityHetu(Stream.of("111111-985K", "170775-973B").collect(toSet()));
+        updateDto.setKaikkiHetut(Stream.of("111111-985K", "170775-973B").collect(toSet()));
 
         henkiloModificationService.forceUpdateHenkilo(updateDto);
         Henkilo henkilo = this.entityManager
@@ -119,15 +119,15 @@ public class HenkiloModificationServiceIntegrationTest {
         assertThat(henkilo)
                 .extracting(Henkilo::getOidHenkilo, Henkilo::getHetu, Henkilo::isYksilointiYritetty)
                 .containsExactly("VTJYKSILOITY1", "111111-985K", false);
-        assertThat(henkilo.getYksiloityHetu()).containsExactlyInAnyOrder("111111-985K", "170775-973B");
+        assertThat(henkilo.getKaikkiHetut()).containsExactlyInAnyOrder("111111-985K", "170775-973B");
     }
 
     @Test
     @WithMockUser(roles = "APP_HENKILONHALLINTA_OPHREKISTERI")
-    public void yksiloityHetuNotModified() {
+    public void kaikkiHetutNotModified() {
         HenkiloForceUpdateDto updateDto = new HenkiloForceUpdateDto();
         updateDto.setOidHenkilo("VTJYKSILOITY1");
-        updateDto.setYksiloityHetu(null);
+        updateDto.setKaikkiHetut(null);
 
         henkiloModificationService.forceUpdateHenkilo(updateDto);
         Henkilo henkilo = this.entityManager
@@ -137,12 +137,12 @@ public class HenkiloModificationServiceIntegrationTest {
         assertThat(henkilo)
                 .extracting(Henkilo::getOidHenkilo, Henkilo::getHetu, Henkilo::isYksilointiYritetty)
                 .containsExactly("VTJYKSILOITY1", "111111-985K", false);
-        assertThat(henkilo.getYksiloityHetu()).containsExactlyInAnyOrder("111111-985K");
+        assertThat(henkilo.getKaikkiHetut()).containsExactlyInAnyOrder("111111-985K");
     }
 
     @Test
     @WithMockUser(roles = "APP_HENKILONHALLINTA_OPHREKISTERI")
-    public void yksiloityHetuAddedOnHetuChange() {
+    public void kaikkiHetutAddedOnHetuChange() {
         HenkiloForceUpdateDto updateDto = new HenkiloForceUpdateDto();
         updateDto.setOidHenkilo("VTJYKSILOITY1");
         updateDto.setHetu("170775-973B");
@@ -155,7 +155,7 @@ public class HenkiloModificationServiceIntegrationTest {
         assertThat(henkilo)
                 .extracting(Henkilo::getOidHenkilo, Henkilo::getHetu, Henkilo::isYksilointiYritetty)
                 .containsExactly("VTJYKSILOITY1", "170775-973B", false);
-        assertThat(henkilo.getYksiloityHetu()).containsExactlyInAnyOrder("111111-985K", "170775-973B");
+        assertThat(henkilo.getKaikkiHetut()).containsExactlyInAnyOrder("111111-985K", "170775-973B");
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloServiceTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloServiceTest.java
@@ -193,8 +193,8 @@ public class HenkiloServiceTest {
     }
 
     @Test
-    public void getOidByHetuWithYksiloityHetu() {
-        given(this.henkiloDataRepositoryMock.findOidByYksiloityHetu("1.2.3.4.5")).willReturn(Optional.of("123456-9999"));
+    public void getOidByHetuWithKaikkiHetut() {
+        given(this.henkiloDataRepositoryMock.findOidByKaikkiHetut("1.2.3.4.5")).willReturn(Optional.of("123456-9999"));
         assertThat(this.service.getOidByHetu("1.2.3.4.5")).isEqualTo("123456-9999");
     }
 

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloServiceTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloServiceTest.java
@@ -193,6 +193,12 @@ public class HenkiloServiceTest {
     }
 
     @Test
+    public void getOidByHetuWithYksiloityHetu() {
+        given(this.henkiloDataRepositoryMock.findOidByYksiloityHetu("1.2.3.4.5")).willReturn(Optional.of("123456-9999"));
+        assertThat(this.service.getOidByHetu("1.2.3.4.5")).isEqualTo("123456-9999");
+    }
+
+    @Test
     public void getHetusAndOids() {
         Henkilo henkiloMock = EntityUtils.createHenkilo("arpa", "arpa", "kuutio", "123456-9999", "1.2.3.4.5", false,
                 "fi", "suomi", "246", new Date(), new Date(0L), "1.2.3.4.1", "arpa@kuutio.fi");

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/OppijaServiceTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/OppijaServiceTest.java
@@ -369,11 +369,11 @@ public class OppijaServiceTest {
     }
 
     @Test
-    public void getOrCreateShouldFindByYksiloityHetu() {
+    public void getOrCreateShouldFindByKaikkiHetut() {
         Henkilo henkilo = Henkilo.builder()
                 .oidHenkilo("oid1")
                 .hetu("180897-945K")
-                .yksiloityHetu(Stream.of("180897-945K", "180897-787F").collect(toSet()))
+                .kaikkiHetut(Stream.of("180897-945K", "180897-787F").collect(toSet()))
                 .etunimet("etu")
                 .kutsumanimi("suku")
                 .sukunimi("suku")

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/OppijaServiceTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/OppijaServiceTest.java
@@ -369,6 +369,41 @@ public class OppijaServiceTest {
     }
 
     @Test
+    public void getOrCreateShouldFindByYksiloityHetu() {
+        Henkilo henkilo = Henkilo.builder()
+                .oidHenkilo("oid1")
+                .hetu("180897-945K")
+                .yksiloityHetu(Stream.of("180897-945K", "180897-787F").collect(toSet()))
+                .etunimet("etu")
+                .kutsumanimi("suku")
+                .sukunimi("suku")
+                .created(new Date())
+                .modified(new Date())
+                .build();
+        henkiloRepository.save(henkilo);
+        OppijaTuontiCreateDto createDto = OppijaTuontiCreateDto.builder()
+                .henkilot(Stream.of(OppijaTuontiRiviCreateDto.builder()
+                        .tunniste("tunniste1")
+                        .henkilo(OppijaTuontiRiviCreateDto.OppijaTuontiRiviHenkiloCreateDto.builder()
+                                .hetu("180897-787F")
+                                .etunimet("etu")
+                                .kutsumanimi("etu")
+                                .sukunimi("suku")
+                                .build())
+                        .build())
+                        .collect(toList()))
+                .build();
+
+        OppijaTuontiReadDto readDto = create(createDto);
+
+        assertThat(readDto.getId()).isNotNull();
+        assertThat(readDto.getHenkilot())
+                .extracting(OppijaTuontiRiviReadDto::getTunniste, t -> t.getHenkilo().getOid())
+                .containsExactly(tuple("tunniste1", "oid1"));
+        assertThat(henkiloRepository.findAll()).hasSize(1);
+    }
+
+    @Test
     public void getOrCreateShouldFindByPassinumero() {
         Henkilo henkilo = Henkilo.builder()
                 .oidHenkilo("oid1")

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
@@ -77,7 +77,7 @@ public class YksilointiITest {
     @Test
     @WithMockUser(value = "1.2.3.4.5", roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
     public void yksiloiAutomaattisestiHetuMuutosUusiHetuYksiloityEnsin() {
-        String uusiHetu = "190198-727T";
+        String uusiHetu = "200198-7484";
         String vanhaHetu = "190198-5259";
         YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
         yksiloityHenkilo.setHetu(uusiHetu);
@@ -106,12 +106,16 @@ public class YksilointiITest {
         assertThat(henkiloRepository.findByOidHenkilo(vanhaOid)).hasValueSatisfying(henkiloByVanhaOid -> {
             assertThat(henkiloByVanhaOid)
                     .returns(null, Henkilo::getHetu)
+                    .returns(LocalDate.of(1998, Month.JANUARY, 19), Henkilo::getSyntymaaika)
+                    .returns("1", Henkilo::getSukupuoli)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
         assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
             assertThat(henkiloByUusiOid)
                     .returns(uusiHetu, Henkilo::getHetu)
+                    .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
+                    .returns("2", Henkilo::getSukupuoli)
                     .returns(uusiOid, Henkilo::getOppijanumero)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
@@ -121,7 +125,7 @@ public class YksilointiITest {
     @Test
     @WithMockUser(value = "1.2.3.4.5", roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
     public void yksiloiAutomaattisestiHetuMuutosVanhaHetuYksiloityEnsin() {
-        String uusiHetu = "190198-727T";
+        String uusiHetu = "200198-7484";
         String vanhaHetu = "190198-5259";
         YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
         yksiloityHenkilo.setHetu(uusiHetu);
@@ -151,6 +155,8 @@ public class YksilointiITest {
         assertThat(henkiloRepository.findByOidHenkilo(vanhaOid)).hasValueSatisfying(henkiloByVanhaOid -> {
             assertThat(henkiloByVanhaOid)
                     .returns(uusiHetu, Henkilo::getHetu)
+                    .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
+                    .returns("2", Henkilo::getSukupuoli)
                     .returns(vanhaOid, Henkilo::getOppijanumero)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
@@ -158,6 +164,8 @@ public class YksilointiITest {
         assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
             assertThat(henkiloByUusiOid)
                     .returns(null, Henkilo::getHetu)
+                    .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
+                    .returns("2", Henkilo::getSukupuoli)
                     .returns(null, Henkilo::getOppijanumero)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
@@ -236,7 +244,7 @@ public class YksilointiITest {
     @Test
     @WithMockUser(value = "1.2.3.4.5", roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
     public void yliajaHenkilonTiedotHetuMuutosUusiHetuYksiloityEnsin() {
-        String uusiHetu = "190198-727T";
+        String uusiHetu = "200198-7484";
         String vanhaHetu = "190198-5259";
         YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
         yksiloityHenkilo.setHetu(uusiHetu);
@@ -266,12 +274,16 @@ public class YksilointiITest {
         assertThat(henkiloRepository.findByOidHenkilo(vanhaOid)).hasValueSatisfying(henkiloByVanhaOid -> {
             assertThat(henkiloByVanhaOid)
                     .returns(null, Henkilo::getHetu)
+                    .returns(LocalDate.of(1998, Month.JANUARY, 19), Henkilo::getSyntymaaika)
+                    .returns("1", Henkilo::getSukupuoli)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
         assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
             assertThat(henkiloByUusiOid)
                     .returns(uusiHetu, Henkilo::getHetu)
+                    .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
+                    .returns("2", Henkilo::getSukupuoli)
                     .returns(uusiOid, Henkilo::getOppijanumero)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
@@ -281,7 +293,7 @@ public class YksilointiITest {
     @Test
     @WithMockUser(value = "1.2.3.4.5", roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
     public void yliajaHenkilonTiedotHetuMuutosVanhaHetuYksiloityEnsin() {
-        String uusiHetu = "190198-727T";
+        String uusiHetu = "200198-7484";
         String vanhaHetu = "190198-5259";
         YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
         yksiloityHenkilo.setHetu(uusiHetu);
@@ -313,6 +325,8 @@ public class YksilointiITest {
         assertThat(henkiloRepository.findByOidHenkilo(vanhaOid)).hasValueSatisfying(henkiloByVanhaOid -> {
             assertThat(henkiloByVanhaOid)
                     .returns(uusiHetu, Henkilo::getHetu)
+                    .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
+                    .returns("2", Henkilo::getSukupuoli)
                     .returns(vanhaOid, Henkilo::getOppijanumero)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
@@ -320,6 +334,8 @@ public class YksilointiITest {
         assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
             assertThat(henkiloByUusiOid)
                     .returns(null, Henkilo::getHetu)
+                    .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
+                    .returns("2", Henkilo::getSukupuoli)
                     .returns(null, Henkilo::getOppijanumero)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
@@ -108,6 +108,7 @@ public class YksilointiITest {
                     .returns(null, Henkilo::getHetu)
                     .returns(LocalDate.of(1998, Month.JANUARY, 19), Henkilo::getSyntymaaika)
                     .returns("1", Henkilo::getSukupuoli)
+                    .returns(null, Henkilo::getOppijanumero)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
@@ -11,6 +11,8 @@ import fi.vm.sade.oppijanumerorekisteri.models.AsiayhteysKayttooikeus;
 import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.repositories.AsiayhteysHakemusRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.AsiayhteysKayttooikeusRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.YksiloityHetuRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.criteria.HenkiloCriteria;
 import fi.vm.sade.rajapinnat.vtj.api.YksiloityHenkilo;
 import org.joda.time.DateTime;
@@ -57,6 +59,10 @@ public class YksilointiITest {
     @Autowired
     private HenkiloModificationService henkiloModificationService;
     @Autowired
+    private HenkiloRepository henkiloRepository;
+    @Autowired
+    private YksiloityHetuRepository yksiloityHetuRepository;
+    @Autowired
     private AsiayhteysHakemusRepository asiayhteysHakemusRepository;
     @Autowired
     private AsiayhteysKayttooikeusRepository asiayhteysKayttooikeusRepository;
@@ -66,6 +72,96 @@ public class YksilointiITest {
     @After
     public void cleanup() {
         databaseService.truncate();
+    }
+
+    @Test
+    @WithMockUser(value = "1.2.3.4.5", roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
+    public void yksiloiAutomaattisestiHetuMuutosUusiHetuYksiloityEnsin() {
+        String uusiHetu = "190198-727T";
+        String vanhaHetu = "190198-5259";
+        YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
+        yksiloityHenkilo.setHetu(uusiHetu);
+        yksiloityHenkilo.setKutsumanimi("Teppo");
+        yksiloityHenkilo.setEtunimi("Teppo");
+        yksiloityHenkilo.setSukunimi("Testaaja");
+        when(vtjClientMock.fetchHenkilo(eq(uusiHetu))).thenReturn(Optional.of(yksiloityHenkilo));
+        when(vtjClientMock.fetchHenkilo(eq(vanhaHetu))).thenReturn(Optional.of(yksiloityHenkilo));
+
+        HenkiloCreateDto henkiloUusiHetuCreateDto = new HenkiloCreateDto();
+        henkiloUusiHetuCreateDto.setHetu(uusiHetu);
+        henkiloUusiHetuCreateDto.setKutsumanimi("Teppo");
+        henkiloUusiHetuCreateDto.setEtunimet("Teppo");
+        henkiloUusiHetuCreateDto.setSukunimi("Testaaja");
+        String uusiOid = henkiloModificationService.createHenkilo(henkiloUusiHetuCreateDto).getOidHenkilo();
+        yksilointiService.yksiloiAutomaattisesti(uusiOid);
+
+        HenkiloCreateDto henkiloVanhaHetuCreateDto = new HenkiloCreateDto();
+        henkiloVanhaHetuCreateDto.setHetu(vanhaHetu);
+        henkiloVanhaHetuCreateDto.setKutsumanimi("Teppo");
+        henkiloVanhaHetuCreateDto.setEtunimet("Teppo");
+        henkiloVanhaHetuCreateDto.setSukunimi("Testaaja");
+        String vanhaOid = henkiloModificationService.createHenkilo(henkiloVanhaHetuCreateDto).getOidHenkilo();
+        yksilointiService.yksiloiAutomaattisesti(vanhaOid);
+
+        assertThat(henkiloRepository.findByOidHenkilo(vanhaOid)).hasValueSatisfying(henkiloByVanhaOid -> {
+            assertThat(henkiloByVanhaOid)
+                    .returns(null, Henkilo::getHetu)
+                    .returns(false, Henkilo::isYksiloityVTJ);
+        });
+        assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
+        assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
+            assertThat(henkiloByUusiOid)
+                    .returns(uusiHetu, Henkilo::getHetu)
+                    .returns(uusiOid, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksiloityVTJ);
+        });
+        assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
+    }
+
+    @Test
+    @WithMockUser(value = "1.2.3.4.5", roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
+    public void yksiloiAutomaattisestiHetuMuutosVanhaHetuYksiloityEnsin() {
+        String uusiHetu = "190198-727T";
+        String vanhaHetu = "190198-5259";
+        YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
+        yksiloityHenkilo.setHetu(uusiHetu);
+        yksiloityHenkilo.setKutsumanimi("Teppo");
+        yksiloityHenkilo.setEtunimi("Teppo");
+        yksiloityHenkilo.setSukunimi("Testaaja");
+        when(vtjClientMock.fetchHenkilo(eq(uusiHetu))).thenReturn(Optional.of(yksiloityHenkilo));
+        when(vtjClientMock.fetchHenkilo(eq(vanhaHetu))).thenReturn(Optional.of(yksiloityHenkilo));
+
+        HenkiloCreateDto henkiloVanhaHetuCreateDto = new HenkiloCreateDto();
+        henkiloVanhaHetuCreateDto.setHetu(vanhaHetu);
+        henkiloVanhaHetuCreateDto.setKutsumanimi("Teppo");
+        henkiloVanhaHetuCreateDto.setEtunimet("Teppo");
+        henkiloVanhaHetuCreateDto.setSukunimi("Testaaja");
+        String vanhaOid = henkiloModificationService.createHenkilo(henkiloVanhaHetuCreateDto).getOidHenkilo();
+
+        HenkiloCreateDto henkiloUusiHetuCreateDto = new HenkiloCreateDto();
+        henkiloUusiHetuCreateDto.setHetu(uusiHetu);
+        henkiloUusiHetuCreateDto.setKutsumanimi("Teppo");
+        henkiloUusiHetuCreateDto.setEtunimet("Teppo");
+        henkiloUusiHetuCreateDto.setSukunimi("Testaaja");
+        String uusiOid = henkiloModificationService.createHenkilo(henkiloUusiHetuCreateDto).getOidHenkilo();
+
+        yksilointiService.yksiloiAutomaattisesti(vanhaOid);
+        yksilointiService.yksiloiAutomaattisesti(uusiOid);
+
+        assertThat(henkiloRepository.findByOidHenkilo(vanhaOid)).hasValueSatisfying(henkiloByVanhaOid -> {
+            assertThat(henkiloByVanhaOid)
+                    .returns(uusiHetu, Henkilo::getHetu)
+                    .returns(vanhaOid, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksiloityVTJ);
+        });
+        assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
+        assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
+            assertThat(henkiloByUusiOid)
+                    .returns(null, Henkilo::getHetu)
+                    .returns(null, Henkilo::getOppijanumero)
+                    .returns(false, Henkilo::isYksiloityVTJ);
+        });
+        assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).isEmpty();
     }
 
     @Test
@@ -135,6 +231,99 @@ public class YksilointiITest {
                 .returns(true, from(HenkiloReadDto::getYksiloityVTJ));
         assertThat(henkiloService.findHenkiloOidsModifiedSince(new HenkiloCriteria(), modifiedSince, 0, 2))
                 .containsExactly(henkiloReadDto.getOidHenkilo());
+    }
+
+    @Test
+    @WithMockUser(value = "1.2.3.4.5", roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
+    public void yliajaHenkilonTiedotHetuMuutosUusiHetuYksiloityEnsin() {
+        String uusiHetu = "190198-727T";
+        String vanhaHetu = "190198-5259";
+        YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
+        yksiloityHenkilo.setHetu(uusiHetu);
+        yksiloityHenkilo.setKutsumanimi("Teppo");
+        yksiloityHenkilo.setEtunimi("Teppo");
+        yksiloityHenkilo.setSukunimi("Testaaja");
+        when(vtjClientMock.fetchHenkilo(eq(uusiHetu))).thenReturn(Optional.of(yksiloityHenkilo));
+        when(vtjClientMock.fetchHenkilo(eq(vanhaHetu))).thenReturn(Optional.of(yksiloityHenkilo));
+
+        HenkiloCreateDto henkiloUusiHetuCreateDto = new HenkiloCreateDto();
+        henkiloUusiHetuCreateDto.setHetu(uusiHetu);
+        henkiloUusiHetuCreateDto.setKutsumanimi("Teppo");
+        henkiloUusiHetuCreateDto.setEtunimet("Teppo");
+        henkiloUusiHetuCreateDto.setSukunimi("Testaaja");
+        String uusiOid = henkiloModificationService.createHenkilo(henkiloUusiHetuCreateDto).getOidHenkilo();
+        yksilointiService.yksiloiAutomaattisesti(uusiOid);
+
+        HenkiloCreateDto henkiloVanhaHetuCreateDto = new HenkiloCreateDto();
+        henkiloVanhaHetuCreateDto.setHetu(vanhaHetu);
+        henkiloVanhaHetuCreateDto.setKutsumanimi("Tiina");
+        henkiloVanhaHetuCreateDto.setEtunimet("Tiina");
+        henkiloVanhaHetuCreateDto.setSukunimi("Testaaja");
+        String vanhaOid = henkiloModificationService.createHenkilo(henkiloVanhaHetuCreateDto).getOidHenkilo();
+        yksilointiService.yksiloiAutomaattisesti(vanhaOid);
+        yksilointiService.yliajaHenkilonTiedot(vanhaOid);
+
+        assertThat(henkiloRepository.findByOidHenkilo(vanhaOid)).hasValueSatisfying(henkiloByVanhaOid -> {
+            assertThat(henkiloByVanhaOid)
+                    .returns(null, Henkilo::getHetu)
+                    .returns(false, Henkilo::isYksiloityVTJ);
+        });
+        assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
+        assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
+            assertThat(henkiloByUusiOid)
+                    .returns(uusiHetu, Henkilo::getHetu)
+                    .returns(uusiOid, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksiloityVTJ);
+        });
+        assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
+    }
+
+    @Test
+    @WithMockUser(value = "1.2.3.4.5", roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
+    public void yliajaHenkilonTiedotHetuMuutosVanhaHetuYksiloityEnsin() {
+        String uusiHetu = "190198-727T";
+        String vanhaHetu = "190198-5259";
+        YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
+        yksiloityHenkilo.setHetu(uusiHetu);
+        yksiloityHenkilo.setKutsumanimi("Teppo");
+        yksiloityHenkilo.setEtunimi("Teppo");
+        yksiloityHenkilo.setSukunimi("Testaaja");
+        when(vtjClientMock.fetchHenkilo(eq(uusiHetu))).thenReturn(Optional.of(yksiloityHenkilo));
+        when(vtjClientMock.fetchHenkilo(eq(vanhaHetu))).thenReturn(Optional.of(yksiloityHenkilo));
+
+        HenkiloCreateDto henkiloVanhaHetuCreateDto = new HenkiloCreateDto();
+        henkiloVanhaHetuCreateDto.setHetu(vanhaHetu);
+        henkiloVanhaHetuCreateDto.setKutsumanimi("Tiina");
+        henkiloVanhaHetuCreateDto.setEtunimet("Tiina");
+        henkiloVanhaHetuCreateDto.setSukunimi("Testaaja");
+        String vanhaOid = henkiloModificationService.createHenkilo(henkiloVanhaHetuCreateDto).getOidHenkilo();
+
+        HenkiloCreateDto henkiloUusiHetuCreateDto = new HenkiloCreateDto();
+        henkiloUusiHetuCreateDto.setHetu(uusiHetu);
+        henkiloUusiHetuCreateDto.setEtunimet("Tiina");
+        henkiloUusiHetuCreateDto.setKutsumanimi("Tiina");
+        henkiloUusiHetuCreateDto.setSukunimi("Testaaja");
+        String uusiOid = henkiloModificationService.createHenkilo(henkiloUusiHetuCreateDto).getOidHenkilo();
+
+        yksilointiService.yksiloiAutomaattisesti(vanhaOid);
+        yksilointiService.yksiloiAutomaattisesti(uusiOid);
+        yksilointiService.yliajaHenkilonTiedot(vanhaOid);
+        yksilointiService.yliajaHenkilonTiedot(uusiOid);
+
+        assertThat(henkiloRepository.findByOidHenkilo(vanhaOid)).hasValueSatisfying(henkiloByVanhaOid -> {
+            assertThat(henkiloByVanhaOid)
+                    .returns(uusiHetu, Henkilo::getHetu)
+                    .returns(vanhaOid, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksiloityVTJ);
+        });
+        assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
+        assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
+            assertThat(henkiloByUusiOid)
+                    .returns(null, Henkilo::getHetu)
+                    .returns(null, Henkilo::getOppijanumero)
+                    .returns(false, Henkilo::isYksiloityVTJ);
+        });
+        assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).isEmpty();
     }
 
     @Test
@@ -247,7 +436,7 @@ public class YksilointiITest {
         henkiloCreateDtoDuplicate.setSukunimi("henkilo");
         henkiloCreateDtoDuplicate.setHetu("170498-993H");
         henkiloCreateDtoDuplicate.setYksiloityVTJ(true);
-        this.henkiloModificationService.createHenkilo(henkiloCreateDtoDuplicate);
+        String duplikaattiOid = this.henkiloModificationService.createHenkilo(henkiloCreateDtoDuplicate).getOidHenkilo();
 
         YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
         yksiloityHenkilo.setEtunimi("teppo");
@@ -258,15 +447,17 @@ public class YksilointiITest {
 
         this.yksilointiService.yksiloiAutomaattisesti(yksiloitavaOid);
 
-        Henkilo henkilo = henkiloService.getEntityByOid(yksiloitavaOid);
-        assertThat(henkilo)
+        assertThat(henkiloService.getEntityByOid(duplikaattiOid))
                 .extracting(henkilo1 -> tuple(henkilo1.getHetu(), henkilo1.isYksiloityVTJ()))
                 .contains(tuple("170498-993H", true));
-        List<HenkiloReadDto> slaves = this.henkiloService.findSlavesByMasterOid(yksiloitavaOid);
-        assertThat(slaves)
+        assertThat(henkiloService.getEntityByOid(yksiloitavaOid))
+                .extracting(henkilo1 -> tuple(henkilo1.getHetu(), henkilo1.isYksiloityVTJ()))
+                .contains(tuple(null, false));
+        assertThat(henkiloService.findSlavesByMasterOid(duplikaattiOid))
                 .hasSize(1)
                 .extracting(HenkiloReadDto::getHetu)
                 .containsNull();
+        assertThat(henkiloService.findSlavesByMasterOid(yksiloitavaOid)).isEmpty();
         verify(kayttooikeusClientMock).passivoiHenkilo(anyString(), eq("1.2.3.4.5"));
     }
 
@@ -288,7 +479,7 @@ public class YksilointiITest {
         henkiloCreateDtoDuplicate.setSukunimi("henkilo");
         henkiloCreateDtoDuplicate.setHetu("170498-993H");
         henkiloCreateDtoDuplicate.setYksiloityVTJ(true);
-        this.henkiloModificationService.createHenkilo(henkiloCreateDtoDuplicate);
+        String duplikaattiOid = this.henkiloModificationService.createHenkilo(henkiloCreateDtoDuplicate).getOidHenkilo();
 
         YksiloityHenkilo yksiloityHenkilo = new YksiloityHenkilo();
         yksiloityHenkilo.setEtunimi("teppo");
@@ -301,15 +492,17 @@ public class YksilointiITest {
 
         this.yksilointiService.yksiloiAutomaattisesti(yksiloitavaOid);
 
-        Henkilo henkilo = henkiloService.getEntityByOid(yksiloitavaOid);
-        assertThat(henkilo)
+        assertThat(henkiloService.getEntityByOid(duplikaattiOid))
                 .extracting(henkilo1 -> tuple(henkilo1.getHetu(), henkilo1.isYksiloityVTJ()))
                 .contains(tuple("170498-993H", true));
-        List<HenkiloReadDto> slaves = this.henkiloService.findSlavesByMasterOid(yksiloitavaOid);
-        assertThat(slaves)
+        assertThat(henkiloService.getEntityByOid(yksiloitavaOid))
+                .extracting(henkilo1 -> tuple(henkilo1.getHetu(), henkilo1.isYksiloityVTJ()))
+                .contains(tuple(null, false));
+        assertThat(henkiloService.findSlavesByMasterOid(duplikaattiOid))
                 .hasSize(1)
                 .extracting(HenkiloReadDto::getHetu)
                 .containsNull();
+        assertThat(henkiloService.findSlavesByMasterOid(yksiloitavaOid)).isEmpty();
         verify(kayttooikeusClientMock).passivoiHenkilo(anyString(), isNull());
     }
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
@@ -12,7 +12,7 @@ import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.repositories.AsiayhteysHakemusRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.AsiayhteysKayttooikeusRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
-import fi.vm.sade.oppijanumerorekisteri.repositories.YksiloityHetuRepository;
+import fi.vm.sade.oppijanumerorekisteri.repositories.HetuRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.criteria.HenkiloCriteria;
 import fi.vm.sade.rajapinnat.vtj.api.YksiloityHenkilo;
 import org.joda.time.DateTime;
@@ -61,7 +61,7 @@ public class YksilointiITest {
     @Autowired
     private HenkiloRepository henkiloRepository;
     @Autowired
-    private YksiloityHetuRepository yksiloityHetuRepository;
+    private HetuRepository hetuRepository;
     @Autowired
     private AsiayhteysHakemusRepository asiayhteysHakemusRepository;
     @Autowired
@@ -112,7 +112,7 @@ public class YksilointiITest {
                     .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
-        assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
+        assertThat(hetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
         assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
             assertThat(henkiloByUusiOid)
                     .returns(uusiHetu, Henkilo::getHetu)
@@ -122,7 +122,7 @@ public class YksilointiITest {
                     .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
-        assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
+        assertThat(hetuRepository.findByHenkiloOid(uusiOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
     }
 
     @Test
@@ -164,7 +164,7 @@ public class YksilointiITest {
                     .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
-        assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
+        assertThat(hetuRepository.findByHenkiloOid(vanhaOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
         assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
             assertThat(henkiloByUusiOid)
                     .returns(null, Henkilo::getHetu)
@@ -174,7 +174,7 @@ public class YksilointiITest {
                     .returns(false, Henkilo::isYksilointiYritetty)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
-        assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).isEmpty();
+        assertThat(hetuRepository.findByHenkiloOid(uusiOid)).isEmpty();
     }
 
     @Test
@@ -285,7 +285,7 @@ public class YksilointiITest {
                     .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
-        assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
+        assertThat(hetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
         assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
             assertThat(henkiloByUusiOid)
                     .returns(uusiHetu, Henkilo::getHetu)
@@ -295,7 +295,7 @@ public class YksilointiITest {
                     .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
-        assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
+        assertThat(hetuRepository.findByHenkiloOid(uusiOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
     }
 
     @Test
@@ -339,7 +339,7 @@ public class YksilointiITest {
                     .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
-        assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
+        assertThat(hetuRepository.findByHenkiloOid(vanhaOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
         assertThat(henkiloRepository.findByOidHenkilo(uusiOid)).hasValueSatisfying(henkiloByUusiOid -> {
             assertThat(henkiloByUusiOid)
                     .returns(null, Henkilo::getHetu)
@@ -349,7 +349,7 @@ public class YksilointiITest {
                     .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
-        assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).isEmpty();
+        assertThat(hetuRepository.findByHenkiloOid(uusiOid)).isEmpty();
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiITest.java
@@ -109,6 +109,7 @@ public class YksilointiITest {
                     .returns(LocalDate.of(1998, Month.JANUARY, 19), Henkilo::getSyntymaaika)
                     .returns("1", Henkilo::getSukupuoli)
                     .returns(null, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
@@ -118,6 +119,7 @@ public class YksilointiITest {
                     .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
                     .returns("2", Henkilo::getSukupuoli)
                     .returns(uusiOid, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
@@ -159,6 +161,7 @@ public class YksilointiITest {
                     .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
                     .returns("2", Henkilo::getSukupuoli)
                     .returns(vanhaOid, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
@@ -168,6 +171,7 @@ public class YksilointiITest {
                     .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
                     .returns("2", Henkilo::getSukupuoli)
                     .returns(null, Henkilo::getOppijanumero)
+                    .returns(false, Henkilo::isYksilointiYritetty)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).isEmpty();
@@ -277,6 +281,8 @@ public class YksilointiITest {
                     .returns(null, Henkilo::getHetu)
                     .returns(LocalDate.of(1998, Month.JANUARY, 19), Henkilo::getSyntymaaika)
                     .returns("1", Henkilo::getSukupuoli)
+                    .returns(null, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).isEmpty();
@@ -286,6 +292,7 @@ public class YksilointiITest {
                     .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
                     .returns("2", Henkilo::getSukupuoli)
                     .returns(uusiOid, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
@@ -329,6 +336,7 @@ public class YksilointiITest {
                     .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
                     .returns("2", Henkilo::getSukupuoli)
                     .returns(vanhaOid, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(true, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(vanhaOid)).containsExactlyInAnyOrder(vanhaHetu, uusiHetu);
@@ -338,6 +346,7 @@ public class YksilointiITest {
                     .returns(LocalDate.of(1998, Month.JANUARY, 20), Henkilo::getSyntymaaika)
                     .returns("2", Henkilo::getSukupuoli)
                     .returns(null, Henkilo::getOppijanumero)
+                    .returns(true, Henkilo::isYksilointiYritetty)
                     .returns(false, Henkilo::isYksiloityVTJ);
         });
         assertThat(yksiloityHetuRepository.findByHenkiloOid(uusiOid)).isEmpty();

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiServiceTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/YksilointiServiceTest.java
@@ -86,6 +86,7 @@ public class YksilointiServiceTest {
         doAnswer(AdditionalAnswers.returnsFirstArg()).when(kielisyysRepository).save(any(Kielisyys.class));
         when(kansalaisuusRepository.findOrCreate(anyString()))
                 .thenReturn(EntityUtils.createKansalaisuus("246"));
+        when(duplicateService.linkWithHetu(any(), any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         String hetu = "010101-123N";
         this.henkilo = EntityUtils.createHenkilo("Teppo Taneli", "Teppo", "Testaaja", hetu, this.henkiloOid,

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImplTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImplTest.java
@@ -318,7 +318,7 @@ public class HenkiloModificationServiceImplTest {
     }
 
     @Test
-    public void findOrCreateHenkiloFromPerustietoDtoHenkiloFoundByYksiloityHetu() {
+    public void findOrCreateHenkiloFromPerustietoDtoHenkiloFoundByKaikkiHetut() {
         LocalDate syntymaaika = LocalDate.now();
         Date modified = new Date();
         HenkiloPerustietoDto henkiloPerustietoDtoInput = DtoUtils.createHenkiloPerustietoDto(null, null, null,
@@ -329,7 +329,7 @@ public class HenkiloModificationServiceImplTest {
                 "fi", "suomi", "246", modified, new Date(), "1.2.3.4.1", "arpa@kuutio.fi", syntymaaika);
 
 
-        given(this.henkiloDataRepositoryMock.findByYksiloityHetu(henkiloPerustietoDtoInput.getHetu())).willReturn(Optional.of(henkilo));
+        given(this.henkiloDataRepositoryMock.findByKaikkiHetut(henkiloPerustietoDtoInput.getHetu())).willReturn(Optional.of(henkilo));
         assertThat(this.service.findOrCreateHenkiloFromPerustietoDto(henkiloPerustietoDtoInput).getDto())
                 .isEqualToComparingFieldByFieldRecursively(henkiloPerustietoDtoMock);
     }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImplTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImplTest.java
@@ -318,6 +318,23 @@ public class HenkiloModificationServiceImplTest {
     }
 
     @Test
+    public void findOrCreateHenkiloFromPerustietoDtoHenkiloFoundByYksiloityHetu() {
+        LocalDate syntymaaika = LocalDate.now();
+        Date modified = new Date();
+        HenkiloPerustietoDto henkiloPerustietoDtoInput = DtoUtils.createHenkiloPerustietoDto(null, null, null,
+                "123456-9999", null, null, null, null, null, null, syntymaaika, modified);
+        HenkiloPerustietoDto henkiloPerustietoDtoMock = DtoUtils.createHenkiloPerustietoDto("arpa", "arpa", "kuutio",
+                "123456-9999", "", "fi", "suomi", "246", null, null, syntymaaika, modified);
+        Henkilo henkilo = EntityUtils.createHenkilo("arpa", "arpa", "kuutio", "123456-9999", "", false,
+                "fi", "suomi", "246", modified, new Date(), "1.2.3.4.1", "arpa@kuutio.fi", syntymaaika);
+
+
+        given(this.henkiloDataRepositoryMock.findByYksiloityHetu(henkiloPerustietoDtoInput.getHetu())).willReturn(Optional.of(henkilo));
+        assertThat(this.service.findOrCreateHenkiloFromPerustietoDto(henkiloPerustietoDtoInput).getDto())
+                .isEqualToComparingFieldByFieldRecursively(henkiloPerustietoDtoMock);
+    }
+
+    @Test
     public void createHenkiloShouldSetEmptyHetuToNull() {
         when(henkiloDataRepositoryMock.save(any(Henkilo.class)))
                 .thenAnswer(returnsFirstArg());

--- a/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
+++ b/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
@@ -5,6 +5,9 @@ INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate
 (-4, 0, '170798-915D', 'YKSILOINNISSANIMIPIELESSA', NOW(), NOW(), FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja')
 ;
 
+INSERT INTO yksiloity_hetu (henkilo_id, hetu)
+SELECT id, hetu FROM henkilo WHERE yksiloityvtj = TRUE;
+
 INSERT INTO yksilointivirhe (id, version, aikaleima, poikkeus, henkilo_id) VALUES
 (-1, 0, NOW(), 'fi.vm.sade.oppijanumerorekisteri.exceptions.SuspendableIdentificationException', -3)
 ;


### PR DESCRIPTION
Korjaa samalla:
- yksilöinti ei enää kumoa aikaisempaa yksilöintiä (tapahtui jos ensin yksilöitiin uusi hetu ja tämän jälkeen vanha hetu jolloin vanhan hetun henkilöstä tuli uuden hetun henkilön master)
- "yliajaHenkilonTiedot" osaa tehdä hetumuutoksen

KJHH-1478