### PR TITLE
KJHH-1499: Poistaa oppijanumeron entiteetistä

### DIFF
--- a/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
+++ b/oppijanumerorekisteri-domain/src/main/java/fi/vm/sade/oppijanumerorekisteri/models/Henkilo.java
@@ -158,8 +158,6 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
 
     private String kotikunta; // kunta-koodisto
 
-    private String oppijanumero;
-
     @OneToMany(fetch = FetchType.LAZY, cascade = { CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.REMOVE })
     @JoinColumn(name = "henkilo_id", nullable = false)
     @NotAudited
@@ -320,4 +318,13 @@ public class Henkilo extends IdentifiableAndVersionedEntity {
             this.huoltajat.clear();
         }
     }
+
+    public String getOppijanumero() {
+        if(this.yksiloity || this.yksiloityVTJ) {
+            return oidHenkilo;
+        }
+
+        return null;
+    }
+
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
@@ -436,7 +436,6 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
             if (henkiloCreate.isDuplicate()) {
                 throw new ValidationException("Henkilö on duplikaatti, yksilöintiä ei voida tehdä");
             }
-            henkiloCreate.setOppijanumero(henkiloCreate.getOidHenkilo());
         }
 
         // hylätään tyhjät passinumerot

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImpl.java
@@ -152,7 +152,6 @@ public class YksilointiServiceImpl implements YksilointiService {
 
         henkilo.setYksiloity(true);
         henkilo.setDuplicate(false);
-        henkilo.setOppijanumero(henkilo.getOidHenkilo());
         return henkiloModificationService.update(henkilo);
     }
 
@@ -361,7 +360,6 @@ public class YksilointiServiceImpl implements YksilointiService {
         }
 
         henkilo.addHetu(nykyinenHetu);
-        henkilo.setOppijanumero(henkilo.getOidHenkilo());
 
         updateIfYksiloityValueNotNull(henkilo.getEtunimet(), yksiloityHenkilo.getEtunimi(),henkilo::setEtunimet);
         updateIfYksiloityValueNotNull(henkilo.getSukunimi(), yksiloityHenkilo.getSukunimi(), henkilo::setSukunimi);
@@ -520,7 +518,6 @@ public class YksilointiServiceImpl implements YksilointiService {
         }
 
         henkilo.addHetu(nykyinenHetu);
-        henkilo.setOppijanumero(henkilo.getOidHenkilo());
         henkilo.setEtunimet(yksilointitieto.getEtunimet());
         henkilo.setSukunimi(yksilointitieto.getSukunimi());
         if (HetuUtils.hetuIsValid(uusiHetu)) {


### PR DESCRIPTION
Oppijanumeron poistamisen osa 1. 

Vältetään mahdollinen katko tuotantoasennuksessa, kun lopetetaan oppijanumeron hakeminen kannasta. Eli poistetaan oppijanumero ensin entiteetistä ja kun tämä on asennettu tuotantoon, voidaan osa 2 asentaa, jossa on oppijanumero-kolumnin poistava migraatioskripti. 