### PR TITLE
KJHH-1523: Fix huoltaja update with yhteystieto failing.

### DIFF
--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/HuoltajaCreateDtoMapper.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/HuoltajaCreateDtoMapper.java
@@ -4,6 +4,7 @@ import fi.vm.sade.oppijanumerorekisteri.dto.HuoltajaCreateDto;
 import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
 import fi.vm.sade.oppijanumerorekisteri.models.Kansalaisuus;
 import fi.vm.sade.oppijanumerorekisteri.repositories.KansalaisuusRepository;
+import fi.vm.sade.oppijanumerorekisteri.utils.YhteystietoryhmaUtils;
 import fi.vm.sade.oppijanumerorekisteri.validation.HetuUtils;
 import ma.glasnost.orika.CustomMapper;
 import ma.glasnost.orika.MapperFactory;
@@ -20,12 +21,15 @@ import java.util.stream.Collectors;
 public class HuoltajaCreateDtoMapper {
 
     @Bean
-    public ClassMap<HuoltajaCreateDto, Henkilo> huoltajaCreateDtoHenkiloClassMap(MapperFactory mapperFactory, KansalaisuusRepository kansalaisuusRepository) {
+    public ClassMap<HuoltajaCreateDto, Henkilo> huoltajaCreateDtoHenkiloClassMap(MapperFactory mapperFactory, KansalaisuusRepository kansalaisuusRepository, OrikaConfiguration mapper) {
         return mapperFactory.classMap(HuoltajaCreateDto.class, Henkilo.class)
+                .exclude("yhteystiedotRyhma")
                 .byDefault()
                 .customize(new CustomMapper<HuoltajaCreateDto, Henkilo>() {
                     @Override
                     public void mapAtoB(HuoltajaCreateDto huoltajaCreateDto, Henkilo henkilo, MappingContext context) {
+                        YhteystietoryhmaUtils.updateYhteystiedot(huoltajaCreateDto.getYhteystiedotRyhma(), henkilo.getYhteystiedotRyhma(), true, mapper);
+
                         Optional.ofNullable(huoltajaCreateDto.getKansalaisuusKoodi())
                                 .map(kansalaisuusKoodis -> kansalaisuusKoodis.stream()
                                         .map(kansalaisuusKoodi -> kansalaisuusRepository.findByKansalaisuusKoodi(kansalaisuusKoodi)

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/YhteystietoryhmaUtils.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/YhteystietoryhmaUtils.java
@@ -1,10 +1,19 @@
 package fi.vm.sade.oppijanumerorekisteri.utils;
 
+import fi.vm.sade.oppijanumerorekisteri.dto.YhteystiedotRyhmaDto;
 import fi.vm.sade.oppijanumerorekisteri.dto.YhteystietoTyyppi;
+import fi.vm.sade.oppijanumerorekisteri.mappers.OrikaConfiguration;
 import fi.vm.sade.oppijanumerorekisteri.models.YhteystiedotRyhma;
 import fi.vm.sade.oppijanumerorekisteri.models.Yhteystieto;
+
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 public final class YhteystietoryhmaUtils {
 
@@ -39,6 +48,33 @@ public final class YhteystietoryhmaUtils {
                     return yt;
                 });
         yhteystieto.setYhteystietoArvo(arvo);
+    }
+
+    public static void updateYhteystiedot(Collection<YhteystiedotRyhmaDto> dtoCollection, Collection<YhteystiedotRyhma> yhteystiedotRyhmas, boolean overwriteReadOnly, OrikaConfiguration mapper) {
+        if (dtoCollection != null) {
+            final Collection<YhteystiedotRyhma> readOnlyRyhmat;
+            if (!overwriteReadOnly) {
+                // poistetaan käyttäjän antamista ryhmistä read-only merkityt
+                readOnlyRyhmat = yhteystiedotRyhmas.stream()
+                        .filter(YhteystiedotRyhma::isReadOnly).collect(toList());
+                dtoCollection.removeIf(dto
+                        -> readOnlyRyhmat.stream().anyMatch(entity -> entity.isEquivalentTo(dto)));
+            } else {
+                readOnlyRyhmat = Collections.emptyList();
+            }
+            // rakennetaan ryhmälista uudelleen
+            yhteystiedotRyhmas.clear();
+            yhteystiedotRyhmas.addAll(Stream.concat(
+                    // käyttäjän muokkaukset
+                    dtoCollection.stream().map(yhteystiedotRyhmaDto -> {
+                        YhteystiedotRyhma yhteystiedotRyhma = mapper.map(yhteystiedotRyhmaDto, YhteystiedotRyhma.class);
+                        yhteystiedotRyhma.setId(null);
+                        return yhteystiedotRyhma;
+                    }), readOnlyRyhmat.stream()) // lisätään read-only ryhmät takaisin
+                    .filter(YhteystiedotRyhma::isNotEmpty) // poistetaan tyhjät yhteystietoryhmät (myös read-only)
+                    .collect(toSet()));
+        }
+
     }
 
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
@@ -3,14 +3,9 @@ package fi.vm.sade.oppijanumerorekisteri.services;
 import fi.vm.sade.koodisto.service.types.common.KoodiType;
 import fi.vm.sade.oppijanumerorekisteri.IntegrationTest;
 import fi.vm.sade.oppijanumerorekisteri.clients.KayttooikeusClient;
-import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloForceUpdateDto;
-import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloReadDto;
-import fi.vm.sade.oppijanumerorekisteri.dto.HenkiloUpdateDto;
-import fi.vm.sade.oppijanumerorekisteri.dto.HuoltajaCreateDto;
+import fi.vm.sade.oppijanumerorekisteri.dto.*;
 import fi.vm.sade.oppijanumerorekisteri.exceptions.UnprocessableEntityException;
-import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
-import fi.vm.sade.oppijanumerorekisteri.models.HenkiloViite;
-import fi.vm.sade.oppijanumerorekisteri.models.Kansalaisuus;
+import fi.vm.sade.oppijanumerorekisteri.models.*;
 import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.HenkiloViiteRepository;
 import fi.vm.sade.oppijanumerorekisteri.repositories.YksilointitietoRepository;
@@ -363,6 +358,42 @@ public class HenkiloModificationServiceIntegrationTest {
         Henkilo huoltaja = henkiloModificationService.createHenkilo(huoltajaCreateDto);
         assertThat(huoltaja).extracting(Henkilo::getHetu).containsExactly("271198-9197");
         assertThat(huoltaja.getKansalaisuus()).extracting(Kansalaisuus::getKansalaisuusKoodi).containsExactly("246");
+    }
+
+    @Test
+    @WithMockUser(roles = "APP_HENKILONHALLINTA_OPHREKISTERI")
+    public void huoltajaUpdateExisting() {
+        KoodiType huoltajuustyyppi = new KoodiType();
+        huoltajuustyyppi.setKoodiArvo("03");
+        KoodiType kansalaisuustyyppi = new KoodiType();
+        kansalaisuustyyppi.setKoodiArvo("246");
+        given(this.koodistoService.list(eq(Koodisto.HUOLTAJUUSTYYPPI))).willReturn(Collections.singleton(huoltajuustyyppi));
+        given(this.koodistoService.list(eq(Koodisto.MAAT_JA_VALTIOT_2))).willReturn(Collections.singleton(kansalaisuustyyppi));
+
+        HuoltajaCreateDto huoltajaCreateDto = HuoltajaCreateDto.builder()
+                .hetu("111298-917M")
+                .huoltajuustyyppiKoodi("03")
+                .kansalaisuusKoodi(Collections.singleton("246"))
+                .yksiloityVTJ(true)
+                .yhteystiedotRyhma(Collections.singleton(YhteystiedotRyhmaDto.builder()
+                        .yhteystieto(YhteystietoDto.builder()
+                                .yhteystietoArvo("Y")
+                                .yhteystietoTyyppi(YhteystietoTyyppi.YHTEYSTIETO_SAHKOPOSTI)
+                                .build())
+                        .ryhmaKuvaus("kuvaus")
+                        .ryhmaAlkuperaTieto("alkupera")
+                        .build()))
+                .build();
+        Henkilo lapsi = this.henkiloRepository.findByOidHenkilo("YKSILOINNISSANIMIPIELESSA").orElseThrow(IllegalStateException::new);
+
+        Henkilo huoltaja = henkiloModificationService.findOrCreateHuoltaja(huoltajaCreateDto, lapsi);
+        assertThat(huoltaja)
+                .extracting(Henkilo::getHetu).containsExactly("111298-917M");
+        assertThat(huoltaja.getKansalaisuus()).extracting(Kansalaisuus::getKansalaisuusKoodi).containsExactly("246");
+        assertThat(huoltaja.getYhteystiedotRyhma()).hasSize(1)
+                .flatExtracting(YhteystiedotRyhma::getYhteystieto)
+                .extracting(Yhteystieto::getYhteystietoArvo)
+                .containsExactlyInAnyOrder("Y");
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
+++ b/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
@@ -32,3 +32,11 @@ INSERT INTO yhteystiedot (id, version, yhteystieto_tyyppi, yhteystieto_arvo, yht
 (-1, 0, 'YHTEYSTIETO_SAHKOPOSTI', 'X', -1)
 ;
 
+INSERT INTO kansalaisuus (id, version, kansalaisuuskoodi) VALUES
+(-1, 0, '246')
+;
+
+INSERT INTO henkilo_kansalaisuus (henkilo_id, kansalaisuus_id) VALUES
+(-5, -1)
+;
+

--- a/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
+++ b/oppijanumerorekisteri-service/src/test/resources/sql/henkilo-modification-test.sql
@@ -2,7 +2,8 @@ INSERT INTO henkilo (id, version, hetu, oidhenkilo, created, modified, duplicate
 (-1, 0, '111111-985K', 'VTJYKSILOITY1', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
 (-2, 0, '111111-1234', 'VTJYKSILOITY2', NOW(), NOW(), FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
 (-3, 0, '170798-9330', 'YKSILOINNISSAVIRHE', NOW(), NOW(), FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
-(-4, 0, '170798-915D', 'YKSILOINNISSANIMIPIELESSA', NOW(), NOW(), FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja')
+(-4, 0, '170798-915D', 'YKSILOINNISSANIMIPIELESSA', NOW(), NOW(), FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, 'Teppo Taneli', 'Teppo', 'Testaaja'),
+(-5, 0, '111298-917M', 'HUOLTAJA', NOW(), NOW(), FALSE, FALSE, FALSE, TRUE, FALSE, FALSE, 'Hana Hii', 'Hana', 'Huoltaja')
 ;
 
 INSERT INTO henkilo_hetu (henkilo_id, hetu)
@@ -18,3 +19,16 @@ INSERT INTO yksilointivirhe (id, version, aikaleima, poikkeus, henkilo_id) VALUE
 
 INSERT INTO yksilointitieto (id, version, henkiloid, turvakielto) VALUES
 (-1, 0, -4, FALSE);
+
+INSERT INTO henkilo_huoltaja_suhde (id, version, lapsi_id, huoltaja_id, huoltajuustyyppi_koodi) VALUES
+(-1, 0, -4, -5, '03')
+;
+
+INSERT INTO yhteystiedotryhma (id, version, ryhmakuvaus, henkilo_id, ryhma_alkuperatieto, read_only, yksilointitieto_id) VALUES
+(-1, 0, 'kuvaus', -5, 'alkuperatieto', TRUE, NULL)
+;
+
+INSERT INTO yhteystiedot (id, version, yhteystieto_tyyppi, yhteystieto_arvo, yhteystiedotryhma_id) VALUES
+(-1, 0, 'YHTEYSTIETO_SAHKOPOSTI', 'X', -1)
+;
+


### PR DESCRIPTION
- Korjaa ennestään löytyvän huoltajan jolla on yhteystietoja päivityksen. Kyseessä on reunatapaus jossa huoltaja löytyy ennestään oppijanumerorekisterissä mutta ei ole yksilöity
- Esiintyi muutostietopalvelun virheellisesti antaessa saman (ennestään ONR löytymättömän) huoltajan kaksi kertaa yhdessä kyselyssä jolloin tapahtui päivitysoperaatio luontioperaation lisäksi