### PR TITLE
KJHH-1579: duplikaattilinkitys rikki joissain tapauksissa

### DIFF
--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/DuplicateService.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/DuplicateService.java
@@ -17,12 +17,44 @@ public interface DuplicateService {
 
     List<HenkiloDuplicateDto> getDuplikaatit(HenkiloDuplikaattiCriteria criteria);
 
+    /**
+     * Jos henkilöstä löytyy samalla hetulla toinen henkilö nämä yhdistetään ja hetutiedot siirretään annetulle henkilölle.
+     * Liittyy vahvan tunnistuksen ja kutsuprosessiin tilanteessa jossa tunnus pitää liittää olemassa olevaan yksilöityyn
+     * henkilöön.
+     * Huom. Tätä ei ole tarkoitettu kutsuttavaksi muualta kuin palvelukerrokselta olemassa olevan transaktion sisällä!
+     * @param henkilo Henkilö jolle hetu annetaan
+     * @param hetu Henkilölle annettava henkilötunnus
+     * @return Linkitystiedot
+     */
     LinkResult removeDuplicateHetuAndLink(Henkilo henkilo, String hetu);
 
+    /**
+     * Linkittää hetulla mahdollisesti löytyvän hetullisen henkilön annettuun henkilöön. Jos ennestään löytyvä henkilö on
+     * yksilöity tämä henkilö saa hetun.
+     * Huom. Tätä ei ole tarkoitettu kutsuttavaksi muualta kuin palvelukerrokselta olemassa olevan transaktion sisällä!
+     * @param henkilo Kandidaatti hetun saajaksi
+     * @param hetu Henkilölle annettava henkilötunnus
+     * @return Linkitystiedot
+     */
     LinkResult linkWithHetu(Henkilo henkilo, String hetu);
 
+    /**
+     * Linkittää henkilölle joukon duplikaattihenkilöitä. Jos henkilöä ei ole yksilöity ja joku linkitettävistä henkilöistä
+     * on tämä valitaan uudeksi masteriksi. Korjaa mahdolliset vanhat linkitykset mukaan kaksitasoisesti (master-slave).
+     * Huom. Tätä ei ole tarkoitettu kutsuttavaksi muualta kuin palvelukerrokselta olemassa olevan transaktion sisällä!
+     * @param henkiloOid Kandidaatti master henkilöksi
+     * @param similarHenkiloOids Joukko linkitettäviä duplikaattihenkilöitä.
+     * @return Linkitystiedot
+     */
     LinkResult linkHenkilos(String henkiloOid, List<String> similarHenkiloOids);
 
+    /**
+     * Purkaa kahden henkilön duplikaattilinkityksen.
+     * Huom. Tätä ei ole tarkoitettu kutsuttavaksi muualta kuin palvelukerrokselta olemassa olevan transaktion sisällä!
+     * @param oid Master henkilön oid
+     * @param slaveOid Duplikaattihenkilön oid
+     * @return Linkitystiedot
+     */
     LinkResult unlinkHenkilo(String oid, String slaveOid);
 
     @AllArgsConstructor

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/DuplicateServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/DuplicateServiceImpl.java
@@ -21,6 +21,7 @@ import fi.vm.sade.oppijanumerorekisteri.services.DuplicateService;
 import fi.vm.sade.oppijanumerorekisteri.services.UserDetailsHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
@@ -97,7 +98,7 @@ public class DuplicateServiceImpl implements DuplicateService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     public LinkResult removeDuplicateHetuAndLink(Henkilo henkilo, String hetu) {
         return this.henkiloDataRepository.findByHetu(hetu)
                 .filter((henkiloWithSameHetu) -> !henkiloWithSameHetu.getOidHenkilo().equals(henkilo.getOidHenkilo()))
@@ -116,7 +117,7 @@ public class DuplicateServiceImpl implements DuplicateService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     public LinkResult linkWithHetu(Henkilo henkilo, String hetu) {
         return this.henkiloDataRepository.findByHetu(hetu)
                 .filter(henkiloByHetu -> !henkiloByHetu.equals(henkilo))
@@ -139,7 +140,7 @@ public class DuplicateServiceImpl implements DuplicateService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     public LinkResult linkHenkilos(String henkiloOid, List<String> similarHenkiloOids) {
         similarHenkiloOids = similarHenkiloOids.stream().filter( oid -> !henkiloOid.equals(oid)).distinct().collect(toList());
 
@@ -272,7 +273,7 @@ public class DuplicateServiceImpl implements DuplicateService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     public LinkResult unlinkHenkilo(String oid, String slaveOid) {
         Henkilo master = this.henkiloDataRepository.findByOidHenkilo(oid)
                 .orElseThrow( () -> new NotFoundException("User with oid " + oid + " was not found"));

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
@@ -253,6 +253,7 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
         }
     }
 
+    @Transactional
     @Override
     public Henkilo update(Henkilo henkilo) {
         setSyntymaaikaAndSukupuoliFromHetu(henkilo);
@@ -444,6 +445,7 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
     }
 
     @Override
+    @Transactional
     public List<String> linkHenkilos(String henkiloOid, List<String> similarHenkiloOids) {
         DuplicateService.LinkResult linked = this.duplicateService.linkHenkilos(henkiloOid, similarHenkiloOids);
         linked.forEachModified(this::update);
@@ -451,6 +453,7 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
     }
 
     @Override
+    @Transactional
     public void unlinkHenkilo(String oid, String slaveOid) {
         this.duplicateService.unlinkHenkilo(oid, slaveOid).forEachModified(this::update);
     }


### PR DESCRIPTION
- Korjaa duplikaattilinkityksen mahdollisen transaktio-ongelman
- Korostaa duplicate servicen LinkResult metodien vaativan transaktion
- Lisää dokumentaatiota
