### PR TITLE
Lisää rajapinnan muutostietopalvelun käyttöön

### DIFF
--- a/oppijanumerorekisteri-api/pom.xml
+++ b/oppijanumerorekisteri-api/pom.xml
@@ -22,6 +22,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -32,8 +33,8 @@
             <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/oppijanumerorekisteri-api/pom.xml
+++ b/oppijanumerorekisteri-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>oppijanumerorekisteri</artifactId>
         <groupId>fi.vm.sade.oppijanumerorekisteri</groupId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceReadDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloForceReadDto.java
@@ -1,0 +1,46 @@
+package fi.vm.sade.oppijanumerorekisteri.dto;
+
+import lombok.Setter;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HenkiloForceReadDto {
+
+    private String etunimet;
+    private LocalDate syntymaaika;
+    private LocalDate kuolinpaiva;
+    private String hetu;
+    private Set<String> kaikkiHetut;
+    private String kutsumanimi;
+    private String oidHenkilo;
+    private String oppijanumero;
+    private String sukunimi;
+    private String sukupuoli;
+    private String kotikunta;
+    private Boolean turvakielto;
+    private boolean eiSuomalaistaHetua;
+    private boolean passivoitu;
+    private boolean yksiloity;
+    private boolean yksiloityVTJ;
+    private boolean yksilointiYritetty;
+    private boolean duplicate;
+    private Date created;
+    private Date modified;
+    private Date vtjsynced;
+    private String kasittelijaOid;
+    private KielisyysDto asiointiKieli;
+    private KielisyysDto aidinkieli;
+    private Set<KansalaisuusDto> kansalaisuus = new HashSet<>();;
+    private Set<YhteystiedotRyhmaDto> yhteystiedotRyhma = new HashSet<>();;
+    private Set<HuoltajaCreateDto> huoltajat = new HashSet<>();;
+
+}

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloPerustietoDto.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/dto/HenkiloPerustietoDto.java
@@ -3,9 +3,10 @@ package fi.vm.sade.oppijanumerorekisteri.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import fi.vm.sade.oppijanumerorekisteri.validation.ValidateAsiointikieli;
 import fi.vm.sade.oppijanumerorekisteri.validation.ValidateHetu;
-import lombok.*;
 import lombok.Setter;
+import lombok.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -15,8 +16,8 @@ import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import javax.validation.Valid;
-import static org.springframework.util.StringUtils.isEmpty;
+
+import static fi.vm.sade.oppijanumerorekisteri.utils.StringUtils.isEmpty;
 
 @Getter
 @Setter

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/StringUtils.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/utils/StringUtils.java
@@ -1,0 +1,12 @@
+package fi.vm.sade.oppijanumerorekisteri.utils;
+
+public final class StringUtils {
+
+    private StringUtils() {
+    }
+
+    public static boolean isEmpty(String str) {
+        return str == null || "".equals(str);
+    }
+
+}

--- a/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/validation/HetuConstraintValidator.java
+++ b/oppijanumerorekisteri-api/src/main/java/fi/vm/sade/oppijanumerorekisteri/validation/HetuConstraintValidator.java
@@ -1,6 +1,6 @@
 package fi.vm.sade.oppijanumerorekisteri.validation;
 
-import org.springframework.util.StringUtils;
+import fi.vm.sade.oppijanumerorekisteri.utils.StringUtils;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;

--- a/oppijanumerorekisteri-domain/pom.xml
+++ b/oppijanumerorekisteri-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>oppijanumerorekisteri</artifactId>
         <groupId>fi.vm.sade.oppijanumerorekisteri</groupId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/oppijanumerorekisteri-service/pom.xml
+++ b/oppijanumerorekisteri-service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>fi.vm.sade.oppijanumerorekisteri</groupId>
         <artifactId>oppijanumerorekisteri</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceController.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/controllers/Service2ServiceController.java
@@ -148,11 +148,18 @@ public class Service2ServiceController {
         return this.henkiloService.list(criteria, offset, limit);
     }
 
+    @GetMapping("/henkilo/hetu={hetu}")
+    @PreAuthorize("hasAnyRole('APP_OPPIJANUMEROREKISTERI_MUUTOSTIETOPALVELU')")
+    @ApiOperation("Palauttaa henkilön tiedot muutostietopalvelua varten")
+    public HenkiloForceReadDto getByHetuForMuutostieto(@PathVariable String hetu) {
+        return henkiloService.getByHetuForMuutostieto(hetu);
+    }
+
     @ApiOperation(value = "Päivittää henkilön tietoja muutostietopalvelun antamilla muutoksilla.",
             notes = "Päivittää kutsussa annettuun OID:n täsmäävän henkilön tiedot")
     @PreAuthorize("hasAnyRole('APP_OPPIJANUMEROREKISTERI_MUUTOSTIETOPALVELU')")
     @RequestMapping(value = "/henkilo/muutostiedot", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public HenkiloReadDto forceUpdateHenkilo(@Validated @RequestBody HenkiloForceUpdateDto henkiloUpdateDto) {
+    public HenkiloForceReadDto forceUpdateHenkilo(@Validated @RequestBody HenkiloForceUpdateDto henkiloUpdateDto) {
         return this.henkiloModificationService.forceUpdateHenkilo(henkiloUpdateDto);
     }
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/HuoltajaCreateDtoMapper.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/mappers/HuoltajaCreateDtoMapper.java
@@ -2,6 +2,7 @@ package fi.vm.sade.oppijanumerorekisteri.mappers;
 
 import fi.vm.sade.oppijanumerorekisteri.dto.HuoltajaCreateDto;
 import fi.vm.sade.oppijanumerorekisteri.models.Henkilo;
+import fi.vm.sade.oppijanumerorekisteri.models.HenkiloHuoltajaSuhde;
 import fi.vm.sade.oppijanumerorekisteri.models.Kansalaisuus;
 import fi.vm.sade.oppijanumerorekisteri.repositories.KansalaisuusRepository;
 import fi.vm.sade.oppijanumerorekisteri.utils.YhteystietoryhmaUtils;
@@ -47,4 +48,18 @@ public class HuoltajaCreateDtoMapper {
                 })
                 .toClassMap();
     }
+
+    @Bean
+    public ClassMap<HenkiloHuoltajaSuhde, HuoltajaCreateDto> henkiloHuoltajaSuhdeHuoltajaCreateDtoClassMap(MapperFactory mapperFactory) {
+        return mapperFactory.classMap(HenkiloHuoltajaSuhde.class, HuoltajaCreateDto.class)
+                .byDefault()
+                .customize(new CustomMapper<HenkiloHuoltajaSuhde, HuoltajaCreateDto>() {
+                    @Override
+                    public void mapAtoB(HenkiloHuoltajaSuhde henkiloHuoltajaSuhde, HuoltajaCreateDto huoltajaCreateDto, MappingContext context) {
+                        mapperFacade.map(henkiloHuoltajaSuhde.getHuoltaja(), huoltajaCreateDto);
+                    }
+                })
+                .toClassMap();
+    }
+
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationService.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationService.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface HenkiloModificationService {
     HenkiloUpdateDto updateHenkilo(HenkiloUpdateDto henkiloUpdateDto);
 
-    HenkiloReadDto forceUpdateHenkilo(HenkiloForceUpdateDto henkiloUpdateDto);
+    HenkiloForceReadDto forceUpdateHenkilo(HenkiloForceUpdateDto henkiloUpdateDto);
 
     Henkilo findOrCreateHuoltaja(HuoltajaCreateDto huoltajaCreateDto, Henkilo lapsi);
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloService.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloService.java
@@ -87,4 +87,6 @@ public interface HenkiloService {
     HenkiloOmattiedotDto getOmatTiedot(String oidHenkilo);
 
     List<HenkiloPerustietoDto> getHenkiloPerustietoByHetus(List<String> hetus);
+
+    HenkiloForceReadDto getByHetuForMuutostieto(String hetu);
 }

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImpl.java
@@ -134,7 +134,7 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
     // Values can be saved overwritten and Hetu can be changed even if isYksiloityVTJ() is true.
     @Override
     @Transactional
-    public HenkiloReadDto forceUpdateHenkilo(HenkiloForceUpdateDto henkiloUpdateDto) {
+    public HenkiloForceReadDto forceUpdateHenkilo(HenkiloForceUpdateDto henkiloUpdateDto) {
         final Henkilo henkiloSaved = this.henkiloDataRepository.findByOidHenkilo(henkiloUpdateDto.getOidHenkilo())
                 .orElseThrow(() -> new NotFoundException("Could not find henkilo " + henkiloUpdateDto.getOidHenkilo()));
 
@@ -175,7 +175,7 @@ public class HenkiloModificationServiceImpl implements HenkiloModificationServic
         this.mapper.map(henkiloUpdateDto, henkiloSaved);
 
         linked.forEachModified(this::update);
-        return mapper.map(henkiloSaved, HenkiloReadDto.class);
+        return mapper.map(henkiloSaved, HenkiloForceReadDto.class);
     }
 
 

--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloServiceImpl.java
@@ -319,8 +319,7 @@ public class HenkiloServiceImpl implements HenkiloService {
     @Override
     @Transactional(readOnly = true)
     public HenkiloReadDto getByHetu(String hetu) {
-        Henkilo henkilo = OptionalUtils.or(henkiloDataRepository.findByHetu(hetu),
-                () -> henkiloDataRepository.findByKaikkiHetut(hetu))
+        Henkilo henkilo = findByHetu(hetu)
                 .orElseThrow(() -> new NotFoundException("Henkilöä ei löytynyt henkilötunnuksella " + hetu));
         return mapper.map(henkilo, HenkiloReadDto.class);
     }
@@ -408,5 +407,17 @@ public class HenkiloServiceImpl implements HenkiloService {
                     return hs.getLapsi().getOidHenkilo();
                 })
                 .collect(Collectors.toSet());
+    }
+
+    @Override
+    public HenkiloForceReadDto getByHetuForMuutostieto(String hetu) {
+        return findByHetu(hetu)
+                .map(henkilo -> mapper.map(henkilo, HenkiloForceReadDto.class))
+                .orElseThrow(() -> new NotFoundException(hetu));
+    }
+
+    private Optional<Henkilo> findByHetu(String hetu) {
+        return OptionalUtils.or(henkiloDataRepository.findByHetu(hetu),
+                () -> henkiloDataRepository.findByKaikkiHetut(hetu));
     }
 }

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
@@ -23,14 +23,11 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static fi.vm.sade.oppijanumerorekisteri.AssertPublished.assertPublished;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
@@ -354,6 +351,18 @@ public class HenkiloModificationServiceIntegrationTest {
                 .extracting(HuoltajaCreateDto::getHuoltajuustyyppiKoodi, HuoltajaCreateDto::getHetu)
                 .containsExactly(tuple("03", huoltaja1.getHetu()));
         assertPublished(objectMapper, amazonSNS, 2, "YKSILOINNISSANIMIPIELESSA", "HUOLTAJA");
+    }
+
+    @Test
+    @WithMockUser(roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
+    public void getByHetuForMuutostietoPalauttaaHuoltajan() {
+        String hetu = "170798-915D";
+
+        HenkiloForceReadDto readDto = henkiloService.getByHetuForMuutostieto(hetu);
+
+        assertThat(readDto.getHuoltajat())
+                .extracting(HuoltajaCreateDto::getHuoltajuustyyppiKoodi, HuoltajaCreateDto::getHetu)
+                .containsExactly(tuple("03", "111298-917M"));
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/HenkiloModificationServiceIntegrationTest.java
@@ -23,17 +23,24 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static fi.vm.sade.oppijanumerorekisteri.AssertPublished.assertPublished;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 @IntegrationTest
@@ -78,10 +85,10 @@ public class HenkiloModificationServiceIntegrationTest {
         henkiloForceUpdateDto.setHetu("111111-1234");
         henkiloForceUpdateDto.setKaikkiHetut(Stream.of("111111-1234", "111111-1233").collect(toSet()));
 
-        HenkiloReadDto henkiloReadDto = this.henkiloModificationService.forceUpdateHenkilo(henkiloForceUpdateDto);
+        HenkiloForceReadDto henkiloReadDto = this.henkiloModificationService.forceUpdateHenkilo(henkiloForceUpdateDto);
 
         assertThat(henkiloReadDto)
-                .extracting(HenkiloReadDto::getOidHenkilo, HenkiloReadDto::getHetu, HenkiloReadDto::getYksiloityVTJ, HenkiloReadDto::getKaikkiHetut)
+                .extracting(HenkiloForceReadDto::getOidHenkilo, HenkiloForceReadDto::getHetu, HenkiloForceReadDto::isYksiloityVTJ, HenkiloForceReadDto::getKaikkiHetut)
                 .containsExactly("VTJYKSILOITY1", "111111-1234", true, Stream.of("111111-1234", "111111-1233").collect(toSet()));
 
         Henkilo henkilo = this.henkiloRepository.findByOidHenkilo("VTJYKSILOITY2")
@@ -304,7 +311,7 @@ public class HenkiloModificationServiceIntegrationTest {
         updateDto.setOidHenkilo("VTJYKSILOITY1");
         updateDto.setKutsumanimi("Taneli");
 
-        HenkiloReadDto readDto = henkiloModificationService.forceUpdateHenkilo(updateDto);
+        HenkiloForceReadDto readDto = henkiloModificationService.forceUpdateHenkilo(updateDto);
 
         assertThat(readDto.getEtunimet()).isEqualTo("Teppo Taneli");
         assertThat(readDto.getKutsumanimi()).isEqualTo("Taneli");
@@ -322,6 +329,31 @@ public class HenkiloModificationServiceIntegrationTest {
 
         assertThat(throwable).isInstanceOf(UnprocessableEntityException.class);
         assertPublished(objectMapper, amazonSNS, 0);
+    }
+
+    @Test
+    @WithMockUser(roles = "APP_OPPIJANUMEROREKISTERI_REKISTERINPITAJA")
+    public void forceUpdateHenkiloPalauttaaHuoltajan() {
+        when(koodistoService.list(eq(Koodisto.HUOLTAJUUSTYYPPI))).thenReturn(Stream.of("03", "04")
+                .map(koodi -> new KoodiType() {{ setKoodiArvo(koodi); }}).collect(toList()));
+        when(koodistoService.list(eq(Koodisto.MAAT_JA_VALTIOT_2))).thenReturn(Stream.of("246")
+                .map(koodi -> new KoodiType() {{ setKoodiArvo(koodi); }}).collect(toList()));
+        HenkiloForceUpdateDto updateDto = new HenkiloForceUpdateDto();
+        updateDto.setOidHenkilo("YKSILOINNISSANIMIPIELESSA");
+        HuoltajaCreateDto huoltaja1 = henkiloRepository.findByOidHenkilo("HUOLTAJA")
+                .map(huoltaja -> new HuoltajaCreateDto(huoltaja.getHetu(), huoltaja.getEtunimet(),
+                        huoltaja.getSukunimi(), huoltaja.getSyntymaaika(), huoltaja.isYksiloityVTJ(),
+                        huoltaja.getKansalaisuus().stream().map(Kansalaisuus::getKansalaisuusKoodi).collect(toSet()),
+                        "03", emptySet()))
+                .get();
+        updateDto.setHuoltajat(singleton(huoltaja1));
+
+        HenkiloForceReadDto readDto = henkiloModificationService.forceUpdateHenkilo(updateDto);
+
+        assertThat(readDto.getHuoltajat())
+                .extracting(HuoltajaCreateDto::getHuoltajuustyyppiKoodi, HuoltajaCreateDto::getHetu)
+                .containsExactly(tuple("03", huoltaja1.getHetu()));
+        assertPublished(objectMapper, amazonSNS, 2, "YKSILOINNISSANIMIPIELESSA", "HUOLTAJA");
     }
 
     @Test

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImplTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/HenkiloModificationServiceImplTest.java
@@ -253,7 +253,7 @@ public class HenkiloModificationServiceImplTest {
         input.setSyntymaaika(LocalDate.of(2017, Month.OCTOBER, 6));
         input.setSukunimi("2");
 
-        HenkiloReadDto output = service.forceUpdateHenkilo(input);
+        HenkiloForceReadDto output = service.forceUpdateHenkilo(input);
 
         assertThat(output.getHetu()).isEqualTo("310817A983J");
         ArgumentCaptor<Henkilo> argumentCaptor = ArgumentCaptor.forClass(Henkilo.class);

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>fi.vm.sade.oppijanumerorekisteri</groupId>
     <artifactId>oppijanumerorekisteri</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <organization>


### PR DESCRIPTION
Lisää rajapinnan muutostietopalvelun käyttöön missä henkilön tietojen lisäksi on mukana huoltajat jotta muutostietopalvelu pystyy päivittämään nykyisiä huoltajia oikein.

KJHH-1696