### PR TITLE
Dropataan huoltajasuhteen auditointitaulun not null -rajoitteet.

### DIFF
--- a/oppijanumerorekisteri-service/src/main/resources/db/migration/V20200311134626422__huoltajasuhde_aud_drop_not_null.sql
+++ b/oppijanumerorekisteri-service/src/main/resources/db/migration/V20200311134626422__huoltajasuhde_aud_drop_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE henkilo_huoltaja_suhde_aud ALTER COLUMN updated DROP NOT NULL;
+ALTER TABLE henkilo_huoltaja_suhde_aud ALTER COLUMN created DROP NOT NULL;


### PR DESCRIPTION
Envers näköjään yrittää lisätä/päivittää rivejä, joissa on
null created/updated ja epäonnistuu not null constrainttien takia.