### PR TITLE
Upgrade spring-boot 2.1.17 -> 2.2.12

### DIFF
--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/SessionMappingStorageConfiguration.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/configurations/SessionMappingStorageConfiguration.java
@@ -5,13 +5,13 @@ import fi.vm.sade.oppijanumerorekisteri.configurations.security.OphSessionMappin
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
 
 @Configuration
 public class SessionMappingStorageConfiguration {
 
     @Bean
-    public OphSessionMappingStorage sessionMappingStorage(JdbcTemplate jdbcTemplate, JdbcOperationsSessionRepository sessionRepository) {
+    public OphSessionMappingStorage sessionMappingStorage(JdbcTemplate jdbcTemplate, JdbcIndexedSessionRepository sessionRepository) {
         return new JdbcSessionMappingStorage(jdbcTemplate, sessionRepository);
     }
 

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/OppijaServiceTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/OppijaServiceTest.java
@@ -552,63 +552,63 @@ public class OppijaServiceTest {
                 .build();
         Page<OppijaListDto> result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).containsExactly("oid1");
+        assertThat(result).extracting(OppijaListDto::getOid).containsExactly("oid1");
 
         criteria = OppijaTuontiCriteria.builder()
                 .nimiHaku("ar")
                 .build();
         result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).containsExactly("oid1");
+        assertThat(result).extracting(OppijaListDto::getOid).containsExactly("oid1");
 
         criteria = OppijaTuontiCriteria.builder()
                 .nimiHaku("noppa")
                 .build();
         result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).containsExactly("oid1");
+        assertThat(result).extracting(OppijaListDto::getOid).containsExactly("oid1");
 
         criteria = OppijaTuontiCriteria.builder()
                 .nimiHaku("nop")
                 .build();
         result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).containsExactly("oid1");
+        assertThat(result).extracting(OppijaListDto::getOid).containsExactly("oid1");
 
         criteria = OppijaTuontiCriteria.builder()
                 .nimiHaku("kuutio")
                 .build();
         result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).containsExactly("oid1");
+        assertThat(result).extracting(OppijaListDto::getOid).containsExactly("oid1");
 
         criteria = OppijaTuontiCriteria.builder()
                 .nimiHaku("kuu")
                 .build();
         result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).containsExactly("oid1");
+        assertThat(result).extracting(OppijaListDto::getOid).containsExactly("oid1");
 
         criteria = OppijaTuontiCriteria.builder()
                 .nimiHaku("arpa noppa kuutio")
                 .build();
         result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).containsExactly("oid1");
+        assertThat(result).extracting(OppijaListDto::getOid).containsExactly("oid1");
 
         criteria = OppijaTuontiCriteria.builder()
                 .nimiHaku("noppa kuutio")
                 .build();
         result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).containsExactly("oid1");
+        assertThat(result).extracting(OppijaListDto::getOid).containsExactly("oid1");
 
         criteria = OppijaTuontiCriteria.builder()
                 .nimiHaku("siansaksaa")
                 .build();
         result = this.oppijaService
                 .list(criteria, 1, 100, OppijaTuontiSortKey.CREATED, Sort.Direction.ASC);
-        assertThat(result.iterator()).extracting(OppijaListDto::getOid).isEmpty();
+        assertThat(result).extracting(OppijaListDto::getOid).isEmpty();
 
     }
 

--- a/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImplTest.java
+++ b/oppijanumerorekisteri-service/src/test/java/fi/vm/sade/oppijanumerorekisteri/services/impl/YksilointiServiceImplTest.java
@@ -291,7 +291,7 @@ public class YksilointiServiceImplTest {
         ArgumentCaptor<Yksilointitieto> argumentCaptor = ArgumentCaptor.forClass(Yksilointitieto.class);
         verify(yksilointitietoRepository).save(argumentCaptor.capture());
         Yksilointitieto yksilointitieto = argumentCaptor.getValue();
-        assertThat(yksilointitieto).isNotNull().extracting("etunimet").contains("Teijo Tahvelo");
+        assertThat(yksilointitieto).isNotNull().extracting("etunimet").isEqualTo("Teijo Tahvelo");
         assertThat(yksiloity.getEtunimet()).isEqualTo("Teppo Taneli");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.17.RELEASE</version>
+        <version>2.2.12.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Why is this needed?:
* 2.1.* series is EOL: https://spring.io/blog/2019/12/10/spring-boot-2-1-x-eol-november-1st-2020
* 2.1.* series hibernate version contains bug which prevents integration tests in some environments: https://hibernate.atlassian.net/browse/HHH-13711