### PR TITLE
Fix OppijaServiceImpl use of incorrect YLEISTUNNISTE_LUONTI access right constant

### DIFF
--- a/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/OppijaServiceImpl.java
+++ b/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/OppijaServiceImpl.java
@@ -172,7 +172,7 @@ public class OppijaServiceImpl implements OppijaService {
     @Override
     public org.springframework.data.domain.Page<TuontiRepository.TuontiKooste> tuontiKooste(Pageable pagination, Long id, String author) {
         final boolean isSuperUser = permissionChecker.isSuperUserOrCanReadAll();
-        Set<String> userOrgs = isSuperUser ? Set.of() : permissionChecker.getAllOrganisaatioOids(PALVELU_OPPIJANUMEROREKISTERI, KAYTTOOIKEUS_OPPIJOIDENTUONTI, YLEISTUNNISTE_LUONTI_ACCESS_RIGHT, KAYTTOOIKEUS_TUONTIDATA_READ);
+        Set<String> userOrgs = isSuperUser ? Set.of() : permissionChecker.getAllOrganisaatioOids(PALVELU_OPPIJANUMEROREKISTERI, KAYTTOOIKEUS_OPPIJOIDENTUONTI, YLEISTUNNISTE_LUONTI_ACCESS_RIGHT_LITERAL, KAYTTOOIKEUS_TUONTIDATA_READ);
         return tuontiRepository.getTuontiKooste(isSuperUser, userOrgs, id, author, pagination);
     }
 
@@ -288,7 +288,7 @@ public class OppijaServiceImpl implements OppijaService {
         // muut käyttäjät ainoastaan omista organisaatioista
         if (!permissionChecker.isSuperUserOrCanReadAll()) {
             String kayttajaOid = userDetailsHelper.getCurrentUserOid();
-            Set<String> organisaatioOidsByKayttaja = permissionChecker.getAllOrganisaatioOids(PALVELU_OPPIJANUMEROREKISTERI, KAYTTOOIKEUS_OPPIJOIDENTUONTI, YLEISTUNNISTE_LUONTI_ACCESS_RIGHT, KAYTTOOIKEUS_TUONTIDATA_READ);
+            Set<String> organisaatioOidsByKayttaja = permissionChecker.getAllOrganisaatioOids(PALVELU_OPPIJANUMEROREKISTERI, KAYTTOOIKEUS_OPPIJOIDENTUONTI, YLEISTUNNISTE_LUONTI_ACCESS_RIGHT_LITERAL, KAYTTOOIKEUS_TUONTIDATA_READ);
             if (organisaatioOidsByKayttaja.isEmpty()) {
                 throw new ValidationException(String.format("Käyttäjällä %s ei ole yhtään organisaatiota joista oppijoita haetaan", kayttajaOid));
             }


### PR DESCRIPTION
The `OppijaServiceImpl` methods use the `permissionChecker.getAllOrganisaatioOids(...)`  and `permissionChecker.getOrganisaatioOidsByKayttaja(...)` methods with inconsistent `YLEISTUNNISTE_LUONTI_ACCESS_RIGHT_LITERAL` and `YLEISTUNNISTE_LUONTI_ACCESS_RIGHT` constants as arguments. The [`YLEISTUNNISTE_LUONTI_ACCESS_RIGHT`](https://github.com/Opetushallitus/oppijanumerorekisteri/blob/45d3cbfef2c85efae440acdef4e98ad192203bdc/oppijanumerorekisteri-service/src/main/java/fi/vm/sade/oppijanumerorekisteri/services/impl/PermissionCheckerImpl.java#L31) constant includes the full `APP_OPPIJANUMEROREKISTERI_*` prefix, which leads to the `permissionChecker` checking for an `APP_OPPIJANUMEROREKISTERI_APP_OPPIJANUMEROREKISTERI_YLEISTUNNISTE_LUONTI` role instead of `APP_OPPIJANUMEROREKISTERI_YLEISTUNNISTE_LUONTI`.